### PR TITLE
Fixed stackswitcher button hover effect

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1526,6 +1526,12 @@ headerbar {
         // specificity bump
         @include reload_button_styles($retain_borders: true);
       }
+
+      &:hover {
+        @include button(hover, $headerbar_bg_color);
+        color: $headerbar_fg_color;
+        -gtk-icon-effect: highlight;
+      }
     }
   }
 


### PR DESCRIPTION
currently, stackswitcher buttons do not have the same hover effect than other buttons on a headerbar
This commit adds a hover target for this widget with:
- dark headerbar bg and fg color
- gtk-icon-effect highlight