### PR TITLE
Fixed again stackswitcher button hover effect

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1550,8 +1550,8 @@ headerbar {
       }
 
       &:hover {
-        @include button(hover, $headerbar_bg_color);
-        color: $headerbar_fg_color;
+        @include button(hover, $_bg, $_fg);
+        border-color: _border_color($_bg, true);
         -gtk-icon-effect: highlight;
       }
     }


### PR DESCRIPTION
Until stackswitcher buttons are not included in "normal" ones, we should keep their style aligned