### PR TITLE
Windows control: style buttons only when hover

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4606,16 +4606,21 @@ button.titlebutton {
   border-radius: 100%;
   min-width: 20px;
   min-height: 20px;
-  margin: 0;
-  padding: 0;
+  margin: 0 3px;
+  padding: 1px;
 
-  &, &:hover, &:active { border-width: 1px; }
-  &:not(.close) { @include restyle_button_states($_bg, $_fg) }
+  //&, &:hover, &:active { border-width: 1px; }
+  //&:not(.close) { @include restyle_button_states($_bg, $_fg) }
 
-  &.close {
-    border: none;
-    @include button(normal, $selected_bg_color, white);
-    @include restyle_button_states($selected_bg_color, white, $retain_borders: true);
+  &:hover:not(.close) {
+    @include button(normal, $headerbar_bg_color, white);
+    padding: 0;
+    border-width: 2px;
+    border-color: white;
+  }
+
+  &:hover.close {
+        @include button(normal, $selected_bg_color, white);
   }
 
   .selection-mode & {


### PR DESCRIPTION
According to recent mockup, this PR styles control buttons in order to show circles/red-color only on hover.
Also, it increases space between buttons (+3px on both sides).

![window-controls-hover](https://user-images.githubusercontent.com/2883614/34492227-fd0baeec-efe6-11e7-959d-fb5b35ba99a2.gif)