### PR TITLE
Desaturate colors in unfocused windows

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -3735,16 +3735,16 @@ row {
 
   &:backdrop { transition: $backdrop_transition; }
 
-  &.activatable {
+  &.activatable:not(:backdrop) {
     &.has-open-popup, // this is for indicathing which row generated a popover see https://bugzilla.gnome.org/show_bug.cgi?id=754411
 
     &:hover { background-color: if(variant == light, transparentize($fg_color, 0.9), transparentize($fg_color, 0.95)); }
 
     &:active { box-shadow: inset 0 2px 2px -2px transparentize(black, 0.8); }
 
-    &:backdrop:hover { background-color: transparent; }
+    // &:backdrop:hover { background-color: transparent; }
 
-    &:selected {
+    &:not(:backdrop):selected {
       &:active { box-shadow: inset 0 2px 3px -1px transparentize(black, 0.5); }
 
       &.has-open-popup,

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1099,7 +1099,7 @@ button.color {
     *:selected & { color: mix($selected_fg_color, $selected_bg_color, 80%); }
   }
 
-  &:backdrop { &:backdrop:hover, &:backdrop:hover:selected, & { color: $link_color; /* $selected_bg_color; */ }}
+  &:backdrop { &:backdrop:hover, &:backdrop:hover:selected, & { color: _backdrop_color($link_color); /* $selected_bg_color; */ }}
 
   @at-root %link_selected,
   &:selected,
@@ -1464,7 +1464,7 @@ headerbar {
   color: $headerbar_fg_color;
 
   &:backdrop {
-    background-color: _backdrop_color($headerbar_bg_color);
+    background-color: $backdrop_headerbar_bg_color;
     transition: $backdrop_transition;
   }
 
@@ -1554,7 +1554,7 @@ headerbar {
       // background-color: $bg_color;
       // background-image: none;
       // box-shadow: inset 0 1px $top_hilight;
-      background-color: opacify(_backdrop_color($headerbar_bg_color), 1);
+      background-color: opacify($backdrop_headerbar_bg_color, 1);
       transition: $backdrop_transition;
     }
 
@@ -1820,16 +1820,13 @@ headerbar { // headerbar border rounding
   }
 
   &:checked:not(:indeterminate) {
-    &, &:backdrop {
       font-weight: bold;
       box-shadow: inset 0 -2px $selected_bg_color, inset 0 1px 3px -1px transparentize(black, 0.5);
-    }
+      &:backdrop { box-shadow: inset 0 -2px _backdrop_color($selected_bg_color), inset 0 1px 3px -1px transparentize(black, 0.5); }
   }
 
-  &:not(:checked):hover:not(:indeterminate) {
-    &, &:backdrop {
+  &:not(:backdrop):not(:checked):hover:not(:indeterminate) {
       box-shadow: inset 0 -2px $insensitive_fg_color;
-    }
   }
 }
 
@@ -2068,12 +2065,12 @@ treeview.view {
 menubar,
 .menubar {
   -GtkWidget-window-dragging: true;
-  background-color: lighten($headerbar_bg_color, 2.5%);
-  box-shadow: inset 0 -1px _border_color($headerbar_bg_color);
+  background-color: $menubar_bg_color;
+  box-shadow: inset 0 -1px _border_color($menubar_bg_color);
   color: $headerbar_fg_color;
   padding: 0px;
 
-  &:backdrop { background-color: _backdrop_color(lighten($headerbar_bg_color, 2.5%)) }
+  &:backdrop { background-color: $backdrop_menubar_bg_color; }
 
   > menuitem {
     min-height: 16px;
@@ -2707,8 +2704,8 @@ switch {
     transition: $backdrop_transition;
 
     &:checked {
-      border-color: $c;
-      background-color: $c;
+      border-color: _backdrop_color($c);
+      background-color: _backdrop_color($c);
     }
 
     &:disabled {
@@ -2743,7 +2740,7 @@ switch {
       @include button(backdrop);
     }
 
-    &:checked slider { border-color: if($variant == 'light', $c, _border_color($c)); }
+    &:checked slider { border-color: _backdrop_color($c);; }
 
     &:disabled slider { @include button(backdrop-insensitive); }
   }
@@ -2753,7 +2750,7 @@ switch {
       box-shadow: none;
       border-color: _border_color($c);
 
-      &:backdrop { border-color: _border_color($c); }
+      &:backdrop { border-color: _backdrop_color($c); }
 
       slider:dir(rtl) { border-left-color: $borders_color; }
       slider:dir(ltr) { border-right-color: $borders_color; }
@@ -2873,72 +2870,50 @@ radio {
   }
 }
 
-%check,
-check {
-  -gtk-icon-source: none;
-  border-radius: 3px;
+%check, %radio, check, radio {
+  $c: $dark_fill;
+  $tc: white;
   border-width: 1px;
   padding: 2px;
 
-  @include button(normal, $dark_fill, $edge: none);
-
-  &:hover { @include button(hover-alt, $dark_fill, $edge: none); }
-  &:active { @include button(active, $dark_fill, $edge: none); }
-  &:disabled { @include button(insensitive, $dark_fill, $edge: none); }
-  &:backdrop {
-    @include button(backdrop, $dark_fill, $edge: none);
-    &:disabled { @include button(backdrop-insensitive, $dark_fill, $edge: none); }
+  @each $state, $t in ('', 'normal'), (':hover', 'hover'),
+                      (':active', 'active'), (':backdrop', 'backdrop'),
+                      (':backdrop:disabled', 'backdrop-insensitive'), (':disabled', 'insensitive') {
+    &#{$state} { @include button($t, $c, $edge: none); }
   }
 
   &:checked:not(:indeterminate) {
     $c: $success_color;
-    -gtk-icon-source: -gtk-icontheme('emblem-ok-symbolic');
-    @include button(normal, $c, white, $edge: none);
-    &:active { @include button(active, $c, white, $edge: none); }
-    &:backdrop { @include button(backdrop, $c, white, $edge: none); }
-    &:disabled { @include button(insensitive-active, $c, white, $edge: none); }
+    -gtk-icon-source: -gtk-icontheme('emblem-ok-symbolic'); // use the suru checkmark
+
+    @each $state, $t in ('', 'normal'), (':hover', 'hover'),
+                        (':active', 'active'), (':backdrop', 'backdrop'),
+                        (':backdrop:disabled', 'backdrop-insensitive'), (':disabled', 'insensitive') {
+      &#{$state} { @include button($t, $c, $tc, $edge: none); }
+    }
   }
 
   &:indeterminate {
     $c: $warning_color;
-    -gtk-icon-source: -gtk-icontheme('list-remove-symbolic');
-    @include button(normal, $c, white, $edge: none);
-    &:active { @include button(active, $c, white, $edge: none); }
-    &:backdrop { @include button(backdrop, $c, white, $edge: none); }
-    &:disabled { @include button(insensitive-active, $c, white, $edge: none); }
+    -gtk-icon-source: -gtk-icontheme('list-remove-symbolic'); // use the suru line
+
+    @each $state, $t in ('', 'normal'), (':hover', 'hover'), (':active', 'active'),
+                        (':backdrop', 'backdrop'), (':backdrop:disabled', 'backdrop-insensitive'),
+                        (':disabled', 'insensitive') {
+      &#{$state} { @include button($t, $c, $tc, $edge: none); }
+    }
   }
+}
+
+%check,
+check {
+  -gtk-icon-source: none;
+  border-radius: 3px;
 }
 
 %radio,
 radio {
   border-radius: 100%;
-  border-width: 1px;
-  padding: 2px;
-
-  @include button(normal, $dark_fill, $edge: none);
-
-  &:hover { @include button(hover-alt, $dark_fill, $edge: none); }
-  &:active { @include button(active, $dark_fill, $edge: none); }
-  &:disabled { @include button(insensitive, $dark_fill, $edge: none); }
-  &:backdrop {
-    @include button(backdrop, $dark_fill, $edge: none);
-    &:disabled { @include button(backdrop-insensitive, $dark_fill, $edge: none); }
-  }
-
-  &:checked:not(:indeterminate) { -gtk-icon-source: -gtk-icontheme('emblem-ok-symbolic'); @include button(normal, $success_color, white, $edge: none);
-    &:active { @include button(active, $success_color, white, $edge: none); }
-    &:backdrop { @include button(backdrop, $success_color, white, $edge: none); }
-    &:disabled { @include button(insensitive-active, $success_color, white, $edge: none); }
-  }
-
-  &:indeterminate {
-    $c: $warning_color;
-    -gtk-icon-source: -gtk-icontheme('list-remove-symbolic');
-    @include button(normal, $c, white, $edge: none);
-    &:active { @include button(active, $c, white, $edge: none); }
-    &:backdrop { @include button(backdrop, $c, white, $edge: none); }
-    &:disabled { @include button(insensitive-active, $c, white, $edge: none); }
-  }
 }
 
 // ANIMATION:
@@ -3475,7 +3450,7 @@ progressbar {
   %progressbar_highlight {
     $c: $success_color;
     // border: 1px solid _border_color($c);
-    // border-radius: 3px;
+    border-radius: 3px;
     background-color: $c;
 
     &:disabled {
@@ -3486,6 +3461,8 @@ progressbar {
     &:backdrop {
       // border-color: if($variant=='light', $c,
       //                                    _border_color($c));
+      background-color: _backdrop_color($c);
+
       &:disabled {
         background-color: transparent;
         // border-color: transparent;
@@ -4513,7 +4490,7 @@ decoration {
     border-radius: 0;
     box-shadow: inset 0 0 0 3px $headerbar_bg_color; //, inset 0 1px $top_hilight;
 
-    &:backdrop { box-shadow: inset 0 0 0 3px _backdrop_color($headerbar_bg_color); /*, inset 0 1px $top_hilight;*/ }
+    &:backdrop { box-shadow: inset 0 0 0 3px $backdrop_headerbar_bg_color; /*, inset 0 1px $top_hilight;*/ }
   }
 }
 
@@ -4640,7 +4617,7 @@ headerbar.selection-mode button.titlebutton,
 %selected_items {
   background-color: $selected_bg_color;
 
-  &:backdrop { background-color: transparentize($fg_color, if($variant == 'light', .5, .7)); }
+  &:backdrop { background-color: _backdrop_color($selected_bg_color); }
 
   @at-root %nobg_selected_items, & {
     color: $selected_fg_color;

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -3,8 +3,10 @@
 // generic drawing of more complex things
 
 @function _backdrop_color($c) {
-// returns backdrop shade
-  @return lighten($c, 3%);
+// desaturates the red, green, orange, etc. colors for use in the backdrop state
+// colors are darkened when using the dark theme so they aren't such a light grey
+  @if $variant != 'light' { $c: darken($c, 7.5%); }
+  @return desaturate($c, 75%);
 }
 
 // @function _widget_edge($c:$borders_edge) {
@@ -200,7 +202,7 @@
   //
   // normal button
   //
-    $_bg: if(lightness($c)>50%, $c, lighten($c, 5%));
+    $_bg: if(lightness($c)>40%, $c, lighten($c, 5%));
     color: $tc;
     outline-color: transparentize($tc, 0.7);
     background-color: $_bg;
@@ -216,7 +218,7 @@
   //
   // hovered button
   //
-    $_bg: if(lightness($c)>50%, darken($c, 5%), lighten($c, 8%));
+    $_bg: if(lightness($c)>40%, darken($c, 5%), lighten($c, 8%));
     color: $tc;
     outline-color: transparentize($tc, 0.7);
     background-color: $_bg;
@@ -254,7 +256,7 @@
   //
   // pushed button
   //
-    $_bg: if(lightness($c)>50%, darken($c, 10%), lighten($c, 3%));
+    $_bg: if(lightness($c)>40%, darken($c, 10%), lighten($c, 3%));
     //
     color: $tc;
     outline-color: transparentize($tc, 0.7);
@@ -271,7 +273,7 @@
   //
   // insensitive button
   //
-    $_bg: if($c != $button_bg_color, mix($c, darken($base_color, if(lightness($c)>50%, 0%, 95%)), 85%),
+    $_bg: if($c != $button_bg_color, mix($c, darken($base_color, if(lightness($c)>40%, 0%, 95%)), 85%),
           $insensitive_bg_color);
 
     label, & { color: if($tc != $fg_color, mix($tc, $_bg, 50%), $insensitive_fg_color); }
@@ -286,7 +288,7 @@
   //
   // insensitive pushed button
   //
-    $_bg: darken(mix($c, darken($base_color, if(lightness($c)>50%, 0, 95%)), 85%), 8%);
+    $_bg: darken(mix($c, darken($base_color, if(lightness($c)>40%, 0, 95%)), 85%), 8%);
 
     label, & { color: if($c != $button_bg_color, mix($tc, $_bg, 60%), $insensitive_fg_color); }
 
@@ -300,12 +302,12 @@
   //
   // backdrop button
   //
-    $_bg: if($c != $button_bg_color, $c, $backdrop_bg_color);
+    $_bg: if($c != $button_bg_color, _backdrop_color($c), $backdrop_bg_color);
 
     label, & { color: if($tc != $fg_color, mix($tc, $_bg, 80%), $backdrop_fg_color); }
 
     background-color: $_bg;
-    border-color: if($c != $button_bg_color, _border_color($c), $backdrop_borders_color);
+    border-color: if($c != $button_bg_color, _backdrop_color(_border_color($c)), $backdrop_borders_color);
     box-shadow: none;
   }
 
@@ -313,12 +315,12 @@
   //
   // backdrop pushed button
   //
-    $_bg: darken(mix($c, darken($base_color, if(lightness($c)>50%, 0, 95%)), 85%), 8%);
+    $_bg: if($c != $button_bg_color, _backdrop_color($c), darken(mix($c, darken($base_color, if(lightness($c)>40%, 0, 95%)), 85%), 8%));
 
     label, & { color: if($tc != $fg_color, mix($tc, $_bg, 80%), $backdrop_fg_color); }
 
     background-color: $_bg;
-    border-color: if($c != $button_bg_color, _border_color($c), $backdrop_borders_color);
+    border-color: if($c != $button_bg_color, _backdrop_color(_border_color($c)), $backdrop_borders_color);
     box-shadow: none;
   }
 
@@ -327,12 +329,12 @@
   // backdrop insensitive button
   //
 
-    $_bg: if($c != $button_bg_color, mix($c, darken($base_color, if(lightness($c)>50%, 0, 95%)), 85%), $insensitive_bg_color);
+    $_bg: if($c != $button_bg_color, _backdrop_color(mix($c, darken($base_color, if(lightness($c)>40%, 0, 95%)), 85%)), $insensitive_bg_color);
 
     label, & { color: if($c != $button_bg_color, mix($tc, $_bg, 35%), $backdrop_insensitive_color); }
 
     background-color: $_bg;
-    border-color: if($c != $button_bg_color, _border_color($c), $backdrop_borders_color);
+    border-color: if($c != $button_bg_color, _backdrop_color(_border_color($c)), $backdrop_borders_color);
     box-shadow: none;
   }
 
@@ -341,12 +343,12 @@
   // backdrop insensitive pushed button
   //
 
-    $_bg: darken(mix($c, darken($base_color, if(lightness($c)>50%, 0, 95%)), 85%), 8%);
+    $_bg: if($c != $button_bg_color, _backdrop_color($c), darken(mix($c, darken($base_color, if(lightness($c)>40%, 0, 95%)), 85%), 8%));
 
     label { color: if($c != $button_bg_color, mix($tc, $_bg, 35%), $backdrop_insensitive_color); }
 
     background-color: $_bg;
-    border-color: if($c != $button_bg_color, _border_color($c), $backdrop_borders_color);
+    border-color: if($c != $button_bg_color, _backdrop_color(_border_color($c)), $backdrop_borders_color);
     box-shadow: none;
   }
 
@@ -602,33 +604,28 @@
 //
 // styles infobar
 //
-    &:backdrop, & {
-      label, & { color: $selected_fg_color; }
-      background-color: $c;
-      border-color: darken($c, 10%);
+  background-color: $c;
+
+  selection { background-color: darken($c, 10%); }
+
+  &:backdrop, & {
+    label, & { color: $selected_fg_color; }
+    border-color: _border_color($c);
+  }
+
+  &:backdrop {
+    background-color: _backdrop_color($c);
+    border-color: _backdrop_color(_border_color($c));
+  }
+
+  button {
+    $_bg: darken($c, 10%);
+    $_fg: white;
+      @each $state, $t in ('', 'normal'), (':hover', 'hover'),
+                          (':active', 'active'), (':checked', 'active'),
+                          (':disabled', 'insensitive'), (':backdrop', 'backdrop'),
+                          (':backdrop:disabled', 'backdrop-insensitive'), (':backdrop:active', 'backdrop-active') {
+      &#{$state} { @include button($t, $_bg, $_fg); }
     }
-
-    &:backdrop { background-color: _backdrop_color($c); }
-
-    button {
-      $_bg: darken($c, 12%);
-      @include button(normal, $_bg, $selected_fg_color, none);
-      &:hover { @include button(hover, $_bg, $selected_fg_color, none); }
-      &:active,
-      &:checked { @include button(active, $_bg, $selected_fg_color, none); }
-      &:disabled { @include button(insensitive,$_bg,$selected_fg_color,none); }
-
-      &:backdrop {
-        @include button(backdrop, $_bg, $selected_fg_color, none);
-        border-color: _border_color($c);
-
-        &:disabled {
-          @include button(backdrop-insensitive, $_bg,
-                          $selected_fg_color, none);
-          border-color: _border_color($c);
-        }
-      }
-    }
-
-    selection { background-color: darken($c, 10%); }
+  }
 }

--- a/Communitheme/gtk-3.0/_ubuntu-colors.scss
+++ b/Communitheme/gtk-3.0/_ubuntu-colors.scss
@@ -31,5 +31,8 @@ $terminal_selected_bg: #102A37;
 // $headerbar_bg_color: #2B2B2B;
 // $headerbar_bg_color: #383634; // #333230;
 $headerbar_bg_color: #303030;
+$backdrop_headerbar_bg_color: lighten($headerbar_bg_color, 3%);
+$menubar_bg_color: lighten($headerbar_bg_color, 2.5%);
+$backdrop_menubar_bg_color: lighten($menubar_bg_color, 3%);
 $headerbar_fg_color: $porcelain;
 //


### PR DESCRIPTION
To close issue #11:

- _backdrop_color function is used to desaturate colors
- Backdrop colors that relied on _backdrop_color are now variables
- Tidying up of infobar
- Tidying up of checkboxes and radio buttons