### PR TITLE
Headerbar buttons now have no border on hover/active

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -149,5 +149,5 @@ terminal-window {
  ***********/
 buttonbox.horizontal.linked button.toggle.toolbar-primary-buttons-software {
   // GNOME Software uses a stackswitcher-type button that isn't labeled as such
-  @extend %underline_focus; // TODO: not applying
+  @extend %stackswitcher;
 }

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -519,7 +519,6 @@ button {
     min-width: 16px;
     padding: 4px 8px;
     border: 1px solid;
-    // box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.025);
     border-radius: 5px;
     transition: $button_transition;
 
@@ -1517,10 +1516,12 @@ headerbar {
       @extend %undecorated_button;
 
       color: $tc;
+      &:backdrop { color: $backdrop_fg_color; }
 
-      @each $state, $t in (':hover', 'hover'), (':active', 'active'),
-                          (':checked', 'active'), (':disabled', 'insensitive') {
-        &#{$state} { @include button($t, $c, $tc); }
+      @each $state, $t in (':hover', 'hover'),
+                          (':active, &:checked', 'active'), (':disabled', 'insensitive'),
+                          (':backdrop:active, &:backdrop:checked', 'backdrop-active') {
+        &#{$state} { @include button($t, $c, $tc, $bc: none, $edge: none); }
       }
 
       @each $b_type, $b_color in (suggested-action, $success_color),
@@ -1529,16 +1530,18 @@ headerbar {
           // special buttons are not flat
           @each $state, $t in ('', 'normal'), (':hover', 'hover'),
                               (':active, &:checked', 'active'), (':backdrop', 'backdrop'),
+                              (':backdrop:active, &:backdrop:checked', 'backdrop-active'),
                               (':backdrop:disabled', 'backdrop-insensitive'), (':disabled', 'insensitive') {
-          &#{$state} { @include button($t, $b_color, $tc); } }
+          &#{$state} { @include button($t, $b_color, $tc, $bc: none, $edge: none); } }
         }
       }
     }
 
-    stackswitcher.horizontal.linked.stack-switcher button.text-button {
+    stackswitcher.horizontal.linked.stack-switcher button.text-button, %stackswitcher {
       // style the stackswitcher
       @extend %underline_focus;
       @extend %undecorated_button;
+      min-width: 100px; // include in the extend so stackswitcher-like buttons will inherit it
       border-radius: 0;
       margin: 0 4px;
     }
@@ -1548,7 +1551,7 @@ headerbar {
           // style the pathbar
           $c: $headerbar_bg_color;
           $tc: $headerbar_fg_color;
-          &, &:hover, &:active { @include button(normal, $c, $tc); }
+          &, &:hover, &:active { @include button(normal, $c, $tc, $edge: none); }
           @extend %underline_focus;
         }
       }
@@ -1559,8 +1562,9 @@ headerbar {
       $tc: $headerbar_fg_color;
       @each $state, $t in ('', 'normal'), (':hover', 'hover'),
                           (':active, &:checked', 'active'), (':backdrop', 'backdrop'),
+                          (':backdrop:active, &:backdrop:checked', 'backdrop-active'),
                           (':backdrop:disabled', 'backdrop-insensitive'), (':disabled', 'insensitive') {
-        &#{$state} { @include button($t, $c, $tc); }
+        &#{$state} { @include button($t, $c, $tc, $edge: none); }
       }
     }
   }
@@ -1825,6 +1829,8 @@ headerbar { // headerbar border rounding
  ************/
 %underline_focus {
   // indeterminate is there to lazily force the style
+  transition-property: box-shadow, color;
+
   &:not(:checked):not(:indeterminate) {
     color: $insensitive_fg_color;
     &:not(:backdrop):hover { color: $headerbar_fg_color; box-shadow: inset 0 -2px $insensitive_fg_color; }
@@ -4545,13 +4551,14 @@ button.titlebutton {
   margin: 0;
   padding: 0;
 
+  &:backdrop { color: $backdrop_fg_color; }
+
   &:not(.close) {
     $c: $headerbar_bg_color;
     $tc: $headerbar_fg_color;
-    $edge: false;
 
     @each $state, $t in (':hover', 'hover'), (':active', 'active'), (':disabled', 'insensitive') {
-      &#{$state} { @include button($t, $c, $tc, $edge); }
+      &#{$state} { @include button($t, $c, $tc, $bc: none, $edge: none); }
     }
   }
 
@@ -4562,7 +4569,7 @@ button.titlebutton {
 
     @each $state, $t in ('', 'normal'), (':hover', 'hover'),
     (':active', 'active'), (':disabled', 'insensitive') {
-      &#{$state} { @include button($t, $c, $tc, $edge); }
+      &#{$state} { @include button($t, $c, $tc, $bc: none, $edge: none); }
     }
 
     &:backdrop { background-color: transparent; }

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -149,12 +149,9 @@
 //
 // $c: base color;
 //
-  @if lightness($c)>95% { @return transparentize(black, 0.85); }
-  @else if lightness($c)>90% { @return transparentize(black, 0.85); }
-  @else if lightness($c)>80% { @return transparentize(black, 0.85); }
-  @else if lightness($c)>50% { @return transparentize(black, 0.85); }
-  @else if lightness($c)>40% { @return transparentize(black, 0.7); }
-  @else { @return transparentize(black, 0.6); }
+  @if lightness($c)>40% { @return transparentize(black, 0.85); }
+  @elseif lightness($c)>15% { @return transparentize(black, 0.75); }
+  @else { @return transparentize(black, 0.45); }
 }
 
 @mixin _button_text_shadow ($tc:$fg_color, $bg:$bg_color) {
@@ -178,13 +175,14 @@
   }
 }
 
-@mixin button($t, $c:$button_bg_color, $tc:$fg_color, $edge: true) {
+@mixin button($t, $c:$button_bg_color, $tc:$fg_color, $bc: true, $edge: true) {
 //
 // Button drawing function
 //
 // $t:    button type,
 // $c:    base button color for colored* types
 // $tc:   optional text color for colored* types
+// $bc:   if set to none it draws "fake" borders using $c
 // $edge: set to none to not draw the 3d effect
 //
 // possible $t values:
@@ -195,17 +193,18 @@
 // This mixin sets the $button_fill global variable which containts the button background-image
 //
   $_button_edge: if($edge == none, transparent, _button_hilight_color($c));
-  $_pressed: transparentize(black, 0.6);
+  $_pressed: if(lightness($c)<15%, transparentize(white, 0.87), transparentize(black, 0.6));
 
   @if $t==normal {
   //
   // normal button
   //
-    $_bg: if(lightness($c)>40%, $c, lighten($c, 5%));
+    $_bg: if(lightness($c)<35%, lighten($c, 5%), $c);
     color: $tc;
     outline-color: transparentize($tc, 0.7);
     background-color: $_bg;
-    border-color: if($c != $button_bg_color, _border_color($c), $borders_color);
+    @if($bc == true) { border-color: if($c != $button_bg_color, _border_color($c), $borders_color); }
+    @else { border-color: $_bg; }
     @if $edge == true {
       @if $c != $button_bg_color { border-bottom-color: _border_color($c, true); }
       @include _shadows(inset 0 -1px $_button_edge);
@@ -217,11 +216,12 @@
   //
   // hovered button
   //
-    $_bg: if(lightness($c)>40%, darken($c, 5%), lighten($c, 8%));
+    $_bg: if(lightness($c)<35%, lighten($c, 8%), darken($c, 5%));
     color: $tc;
     outline-color: transparentize($tc, 0.7);
     background-color: $_bg;
-    border-color: _border_color($_bg);
+    @if($bc == true) { border-color: _border_color($_bg); }
+    @else { border-color: $_bg; }
     -gtk-icon-effect: highlight;
     @if $edge == true {
       @if $c != $button_bg_color { border-bottom-color: _border_color($c, true); }
@@ -256,12 +256,13 @@
   //
   // pushed button
   //
-    $_bg: if(lightness($c)>40%, darken($c, 10%), lighten($c, 3%));
+    $_bg: if(lightness($c)<35%, darken($c, 5%), darken($c, 10%));
     //
     color: $tc;
     outline-color: transparentize($tc, 0.7);
     background-color: $_bg;
-    border-color: _border_color($_bg);
+    @if($bc == true) { border-color: _border_color($_bg); }
+    @else { border-color: $_bg; }
     @if $edge == true {
       @if $c != $button_bg_color { border-bottom-color: _border_color($c, true); }
       @include _shadows(inset 0 2px 3px -1px $_pressed);
@@ -273,13 +274,14 @@
   //
   // insensitive button
   //
-    $_bg: if($c != $button_bg_color, mix($c, darken($base_color, if(lightness($c)>40%, 0%, 95%)), 85%),
+    $_bg: if($c != $button_bg_color, mix($c, darken($base_color, if(lightness($c)<35%, 95%, 0%)), 85%),
           $insensitive_bg_color);
 
     label, & { color: if($tc != $fg_color, mix($tc, $_bg, 50%), $insensitive_fg_color); }
 
     background-color: $_bg;
-    border-color: if($c != $button_bg_color, _border_color($c), $insensitive_borders_color);
+    @if($bc == true) { border-color: if($c != $button_bg_color, _border_color($c), $insensitive_borders_color); }
+    @else { border-color: $_bg; }
     @if $edge == true { @include _shadows(inset 0 -1px transparent); }
     @else { box-shadow: none; }
   }
@@ -288,12 +290,13 @@
   //
   // insensitive pushed button
   //
-    $_bg: darken(mix($c, darken($base_color, if(lightness($c)>40%, 0, 95%)), 85%), 8%);
+    $_bg: darken(mix($c, darken($base_color, if(lightness($c)<35%, 95%, 0%)), 85%), 8%);
 
     label, & { color: if($c != $button_bg_color, mix($tc, $_bg, 60%), $insensitive_fg_color); }
 
     background-color: $_bg;
-    border-color: if($c != $button_bg_color, _border_color($c), $insensitive_borders_color);
+    @if($bc == true) { border-color: if($c != $button_bg_color, _border_color($c), $insensitive_borders_color); }
+    @else { border-color: $_bg; }
     @if $edge == true { @include _shadows(inset 0 2px 3px -1px lighten($_pressed, 40%)); }
     @else { box-shadow: none; }
   }
@@ -307,7 +310,8 @@
     label, & { color: if($tc != $fg_color, mix($tc, $_bg, 80%), $backdrop_fg_color); }
 
     background-color: $_bg;
-    border-color: if($c != $button_bg_color, _backdrop_color(_border_color($c)), $backdrop_borders_color);
+    @if($bc == true) { border-color: if($c != $button_bg_color, _backdrop_color(_border_color($c)), $backdrop_borders_color); }
+    @else { border-color: $_bg; }
     box-shadow: none;
   }
 
@@ -315,12 +319,13 @@
   //
   // backdrop pushed button
   //
-    $_bg: if($c != $button_bg_color, _backdrop_color($c), darken(mix($c, darken($base_color, if(lightness($c)>40%, 0, 95%)), 85%), 8%));
+    $_bg: if($c != $button_bg_color, _backdrop_color($c), darken(mix($c, darken($base_color, if(lightness($c)<35%, 95%, 0%)), 85%), 8%));
 
     label, & { color: if($tc != $fg_color, mix($tc, $_bg, 80%), $backdrop_fg_color); }
 
     background-color: $_bg;
-    border-color: if($c != $button_bg_color, _backdrop_color(_border_color($c)), $backdrop_borders_color);
+    @if($bc == true) { border-color: if($c != $button_bg_color, _backdrop_color(_border_color($c)), $backdrop_borders_color); }
+    @else { border-color: $_bg; }
     box-shadow: none;
   }
 
@@ -329,12 +334,13 @@
   // backdrop insensitive button
   //
 
-    $_bg: if($c != $button_bg_color, _backdrop_color(mix($c, darken($base_color, if(lightness($c)>40%, 0, 95%)), 85%)), $insensitive_bg_color);
+    $_bg: if($c != $button_bg_color, _backdrop_color(mix($c, darken($base_color, if(lightness($c)<35%, 95%, 0%)), 85%)), $insensitive_bg_color);
 
     label, & { color: if($c != $button_bg_color, mix($tc, $_bg, 35%), $backdrop_insensitive_color); }
 
     background-color: $_bg;
-    border-color: if($c != $button_bg_color, _backdrop_color(_border_color($c)), $backdrop_borders_color);
+    @if($bc == true) { border-color: if($c != $button_bg_color, _backdrop_color(_border_color($c)), $backdrop_borders_color); }
+    @else { border-color: $_bg; }
     box-shadow: none;
   }
 
@@ -343,12 +349,13 @@
   // backdrop insensitive pushed button
   //
 
-    $_bg: if($c != $button_bg_color, _backdrop_color($c), darken(mix($c, darken($base_color, if(lightness($c)>40%, 0, 95%)), 85%), 8%));
+    $_bg: if($c != $button_bg_color, _backdrop_color($c), darken(mix($c, darken($base_color, if(lightness($c)<35%, 95%, 0%)), 85%), 8%));
 
     label { color: if($c != $button_bg_color, mix($tc, $_bg, 35%), $backdrop_insensitive_color); }
 
     background-color: $_bg;
-    border-color: if($c != $button_bg_color, _backdrop_color(_border_color($c)), $backdrop_borders_color);
+    @if($bc == true) { border-color: if($c != $button_bg_color, _backdrop_color(_border_color($c)), $backdrop_borders_color); }
+    @else { border-color: $_bg; }
     box-shadow: none;
   }
 


### PR DESCRIPTION
Closes issue #19 and also fixes the problem with GNOME Software's stackswitcher-like buttons