### PR TITLE
Fixed popover menu hover color too light

### DIFF
--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -20,7 +20,7 @@ $top_hilight: $borders_edge;
 $dark_fill: $borders_color; // mix($borders_color, $bg_color, 50%);
 $menu_color: if($variant == 'light', $base_color, mix($bg_color, $base_color, 20%));
 $popover_bg_color: $bg_color;
-$popover_hover_color: lighten($bg_color, 5%);
+$popover_hover_color: if($variant=='light', darken($bg_color, 7%), lighten($bg_color, 7%));
 //
 $scrollbar_bg_color: if($variant == 'light', mix($bg_color, $fg_color, 90%), mix($base_color, $bg_color, 50%));
 $scrollbar_slider_color: mix($scrollbar_bg_color, $fg_color, 40%);


### PR DESCRIPTION
- differentiate hover color for light and dark themes
- light themes, color is now lighter by 7% than bg_color
- dark themes, color is now darker by 7% than bg_color

![popover-menu-hover](https://user-images.githubusercontent.com/2883614/34674896-f03999b8-f487-11e7-851c-98b4abedac8a.gif)

closes #21 

  