### PR TITLE
Sass cleanup and tweaks for the dark theme and popover

### DIFF
--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -3,8 +3,8 @@
 
 @import 'ubuntu-colors';
 
-$base_color: if($variant == 'light', #FFFFFF, #1C1B21);
-$bg_color: if($variant == 'light', #FAFAFA, #292933);
+$base_color: if($variant == 'light', #FFFFFF, #292933);
+$bg_color: if($variant == 'light', #FAFAFA, #1C1B21);
 $fg_color: if($variant == 'light', $slate, $porcelain);
 $text_color: transparentize($fg_color, .1);
 //
@@ -17,7 +17,7 @@ $borders_edge: rgba(0, 0, 0, 0.09); // if($variant == 'light', transparentize(wh
 $link_color: $blue; // if($variant == 'light', darken($selected_bg_color, 10%), lighten($selected_bg_color, 20%));
 $link_visited_color: if($variant == 'light', darken($link_color, 20%), lighten($link_color, 10%)); // if($variant == 'light', darken($selected_bg_color, 20%), lighten($selected_bg_color, 10%));
 $top_hilight: $borders_edge;
-$dark_fill: $borders_color; // mix($borders_color, $bg_color, 50%);
+$dark_fill: if($variant == "light", $borders_color, mix($fg_color, $bg_color, 50%));
 $menu_color: if($variant == 'light', $base_color, mix($bg_color, $base_color, 20%));
 $popover_bg_color: $bg_color;
 $popover_hover_color: lighten($bg_color, 5%);
@@ -37,13 +37,14 @@ $neutral_color: $blue;
 //
 $osd_fg_color: $porcelain;
 $osd_text_color: transparentize($osd_fg_color, .1);
-$osd_bg_color: transparentize(#292933, 0.3);
+$osd_bg_color: transparentize(#1C1B21, 0.3);
 $osd_insensitive_bg_color: transparentize(mix($osd_fg_color, opacify($osd_bg_color, 1), 10%), 0.5);
 $osd_insensitive_fg_color: mix($osd_fg_color, opacify($osd_bg_color, 1), 50%);
 $osd_borders_color: transparentize(black, 0.3);
 //
 $sidebar_bg_color: darken(mix($bg_color, $base_color, 50%), 5%);
-$base_hover_color: transparentize($fg_color, 0.95);
+$base_hover_color: transparentize($fg_color, 0.85);
+$base_active_color: transparentize($fg_color, 0.80);
 //
 $tooltip_borders_color: transparentize(white, 0.9);
 $shadow_color: transparentize(black, 0.9);

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1044,7 +1044,8 @@ modelbutton.flat,
 
   @extend %undecorated_button;
 
-  &:hover { background-color: $popover_hover_color; }
+  &:hover { background-color: $base_hover_color; }
+  &:active { background-color: $base_active_color; }
 
   &:selected { @extend %selected_items; }
 
@@ -2127,7 +2128,7 @@ menu,
 .menu,
 .context-menu {
   margin: 4px; // see https://bugzilla.gnome.org/show_bug.cgi?id=591258
-  padding: 2px 0px;
+  // padding: 2px 0px;
   background-color: $menu_color;
   border: 1px solid $borders_color; // adds borders in a non composited env
 
@@ -2136,14 +2137,15 @@ menu,
   &:backdrop { background-color: $backdrop_menu_color; }
 
   menuitem {
-    min-height: 16px;
-    min-width: 40px;
-    padding: 4px 6px;
+    transition: all 100ms $ease-out-quad;
+    min-height: 20px; // 16px;
+    min-width: 36px;
+    padding: 6px 4px; // 4px 6px;
     // text-shadow: none;
 
     &:hover {
-      color: $selected_fg_color;
-      background-color: $selected_bg_color;
+      // color: $selected_fg_color;
+      background-color: $base_hover_color;
     }
 
     &:disabled {
@@ -2159,17 +2161,19 @@ menu,
 
     // submenu indicators
     arrow {
-      min-height: 16px;
+      min-height: 14px;
       min-width: 16px;
 
       &:dir(ltr) {
-        -gtk-icon-source: -gtk-icontheme('pan-end-symbolic');
+        -gtk-icon-source: -gtk-icontheme('go-next-symbolic'); // -gtk-icontheme('pan-end-symbolic');
         margin-left: 10px;
+        margin-right: 10px;
       }
 
       &:dir(rtl) {
-        -gtk-icon-source:-gtk-icontheme('pan-end-symbolic-rtl');
+        -gtk-icon-source: -gtk-icontheme('go-previous-symbolic'); // -gtk-icontheme('pan-end-symbolic-rtl');
         margin-right: 10px;
+        margin-left: 10px;
       }
     }
 
@@ -2191,13 +2195,13 @@ menu,
     &.top {
       margin-top: -6px;
       border-bottom: 1px solid mix($fg_color, $base_color, 10%);
-      -gtk-icon-source: -gtk-icontheme('pan-up-symbolic');
+      -gtk-icon-source: -gtk-icontheme('go-next-symbolic'); // -gtk-icontheme('pan-end-symbolic');
     }
 
     &.bottom {
       margin-bottom: -6px;
       border-top: 1px solid mix($fg_color, $base_color, 10%);
-      -gtk-icon-source: -gtk-icontheme('pan-down-symbolic');
+      -gtk-icon-source: -gtk-icontheme('go-previous-symbolic'); // -gtk-icontheme('pan-end-symbolic-rtl');
     }
 
     &:hover { background-color: mix($fg_color, $base_color, 10%); }
@@ -2230,9 +2234,9 @@ menuitem {
  ***************/
 
 popover.background {
-  padding: 2px;
+  // padding: 2px;
   border-radius: 5px;
-  background-color: $popover_bg_color;
+  background-color: $menu_color; // $popover_bg_color;
 
   .csd &, & { border: 1px solid $borders_color; }
 
@@ -2261,6 +2265,12 @@ popover.background {
     }
 
     &.osd { @extend %osd; }
+  }
+
+  modelbutton {
+    min-height: 24px; // 16px;
+    min-width: 40px;
+    padding: 4px 6px; // 4px 6px;
   }
 
   separator { margin: 3px; }
@@ -2766,7 +2776,7 @@ switch {
     transition: $button_transition;
 
     @include button(normal, white, $edge: none);
-    box-shadow: inset 0 0 0 1px $borders_color;
+    box-shadow: inset 0 0 0 1px if($variant == "light", $borders_color, _border_color($dark_fill));
     // border-color: darken($borders_color, 10%);
   }
 
@@ -3657,7 +3667,8 @@ levelbar {
     }
 
     &.empty {
-      $_bg: transparentize(black, .8);
+      // TODO: this looks kind of ugly
+      $_bg: transparentize(black, if($variant == "light", .8, .7));
       background-color: $_bg;
       // border-color: if($variant == 'light', transparentize($fg_color,0.8), transparentize($fg_color,0.9));
 

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -32,11 +32,11 @@ $button_transition: all 200ms $ease-out-quad;
   // to the adwaita engine: using real CSS properties is faster,
   // and we don't use any outlines for now.
 
-  outline-color: gtkalpha(currentColor, 0.3);
+  outline-color: $blue; // gtkalpha(currentColor, 0.3);
   outline-style: dashed;
   outline-offset: -3px;
   outline-width: 1px;
-  -gtk-outline-radius: 2px;
+  -gtk-outline-radius: 0px;
 
   -gtk-secondary-caret-color: $selected_bg_color
 }
@@ -265,7 +265,7 @@ entry {
     min-height: 24px;
     padding: 4px 8px;
     border: 1px solid;
-    border-radius: 3px;
+    border-radius: 5px;
     transition: all 200ms $ease-out-quad;
 
     @include entry(normal);
@@ -520,6 +520,9 @@ button {
     padding: 4px 8px;
     border: 1px solid;
     border-radius: 5px;
+    outline-color: $blue;
+    outline-offset: -1px;
+    outline-radius: 5px;
     transition: $button_transition;
 
     @include button(normal);
@@ -557,6 +560,7 @@ button {
         @include button(backdrop);
 
         transition: $backdrop_transition;
+        outline-color: $blue;
         -gtk-icon-effect: none;
 
         &:active,
@@ -955,24 +959,29 @@ toolbar.inline-toolbar toolbutton:backdrop {
 %linked_middle {
   border-radius: 0;
   border-right-style: none;
+  -gtk-outline-radius: 0;
 }
 
 %linked {
   @extend %linked_middle;
 
   &:first-child {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-top-left-radius: 5px;
+    border-bottom-left-radius: 5px;
+    -gtk-outline-radius: 5px 0 0 5px ;
+
   }
 
   &:last-child {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-top-right-radius: 5px;
+    border-bottom-right-radius: 5px;
     border-right-style: solid;
+    -gtk-outline-radius: 0 5px 5px 0;
   }
 
   &:only-child {
-    border-radius: 3px;
+    border-radius: 5px;
+    -gtk-outline-radius: 5px;
     border-style: solid;
   }
 }
@@ -980,19 +989,22 @@ toolbar.inline-toolbar toolbutton:backdrop {
 %linked_vertical_middle {
   border-style: solid solid none solid;
   border-radius: 0;
+  -gtk-outline-radius: 0px;
 }
 
 %linked_vertical{
   @extend %linked_vertical_middle;
 
   &:first-child {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+    -gtk-outline-radius: 5px 5px 0 0;
   }
 
   &:last-child {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-bottom-left-radius: 5px;
+    border-bottom-right-radius: 5px;
+    -gtk-outline-radius: 0 0 5px 5px;
     border-style: solid;
   }
 
@@ -1002,7 +1014,8 @@ toolbar.inline-toolbar toolbutton:backdrop {
   }
 
   &:only-child {
-    border-radius: 3px;
+    border-radius: 5px;
+    -gtk-outline-radius: 5px;
     border-style: solid;
   }
 }
@@ -1027,7 +1040,7 @@ modelbutton.flat,
   padding-left: 5px;
   padding-right: 5px;
   border-radius: 3px;
-  outline-offset: -2px;
+  outline-offset: 0; // -2px;
 
   @extend %undecorated_button;
 
@@ -1199,9 +1212,9 @@ spinbutton {
         &:dir(rtl) { border-style: none solid none none; }
       }
 
-      &:dir(ltr):last-child { border-radius: 0 3px 3px 0; }
+      &:dir(ltr):last-child { border-radius: 0 5px 5px 0; }
 
-      &:dir(rtl):first-child { border-radius: 3px 0 0 3px; }
+      &:dir(rtl):first-child { border-radius: 5px 0 0 5px; }
     }
   }
 
@@ -1247,9 +1260,9 @@ spinbutton {
         box-shadow: none;
       }
 
-      &:dir(ltr):last-child { border-radius: 0 3px 3px 0; }
+      &:dir(ltr):last-child { border-radius: 0 5px 5px 0; }
 
-      &:dir(rtl):first-child { border-radius: 3px 0 0 3px; }
+      &:dir(rtl):first-child { border-radius: 5px 0 0 5px; }
     }
   }
 
@@ -1288,12 +1301,12 @@ spinbutton {
     }
 
     %top_button {
-      border-radius: 3px 3px 0 0;
+      border-radius: 5px 5px 0 0;
       border-style: solid solid none solid;
     }
 
     %bottom_button {
-      border-radius: 0 0 3px 3px;
+      border-radius: 0 0 5px 5px;
       border-style: none solid solid solid;
     }
   }
@@ -2278,7 +2291,8 @@ notebook {
         padding-top: 4px;
         margin-bottom: -2px;
         > tab {
-          border-radius: 5px 5px 0 0 ;
+          border-radius: 5px 5px 0 0;
+          outline-radius: 5px 5px 0 0;
           &:checked { border-bottom-color: transparent; }
         }
       }
@@ -2291,6 +2305,7 @@ notebook {
         margin-top: -2px;
         > tab {
           border-radius: 0 0 5px 5px;
+          outline-radius: 0 0 5px 5px;
           &:checked { border-top-color: transparent; }
         }
       }
@@ -2302,7 +2317,8 @@ notebook {
         padding-left: 4px;
         margin-right: -2px;
         > tab {
-          border-radius: 6px 0 0 6px;
+          border-radius: 5px 0 0 5px;
+          outline-radius: 5px 0 0 5px;
           &:checked { border-right-color: transparent; }
         }
       }
@@ -2314,7 +2330,8 @@ notebook {
         padding-right: 4px;
         margin-left: -2px;
         > tab {
-          border-radius: 0 6px 6px 0;
+          border-radius: 0 5px 5px 0;
+          outline-radius: 0 5px 5px 0;
           &:checked { border-left-color: transparent; }
         }
       }
@@ -2390,7 +2407,7 @@ notebook {
       min-height: 30px;
       min-width: 30px;
       padding: 3px 12px;
-      outline-offset: -5px;
+      outline-offset: -1px; // -5px;
       color: $insensitive_fg_color;
       border: 1px solid transparent;
 
@@ -2699,7 +2716,7 @@ switch {
   $c: $success_color;
   font-weight: bold;
   font-size: smaller;
-  outline-offset: -4px;
+  outline-offset: 0; // -4px;
   box-shadow: inset 0 -1px 0 0 $borders_edge, inset 0 2px 0 0 $borders_edge;
   border-radius: 5px;
   color: transparent;
@@ -2742,6 +2759,9 @@ switch {
     min-width: 22px; // 32px; // 44px;
     min-height: 24px; // 20px; // 26px;
     // border: 1px solid;
+    outline-offset: -1px;
+    outline-radius: 5px;
+    outline-color: $blue;
     border-radius: 5px;
     transition: $button_transition;
 
@@ -3115,7 +3135,7 @@ scale {
   trough {
     @extend %scale_trough;
 
-    outline-offset: 2px;
+    outline-offset: 3px;
     -gtk-outline-radius: 5px;
   }
 
@@ -3524,30 +3544,31 @@ progressbar {
       // &:disabled { border-color: transparent; }
     }
   }
-
+// TODO: maybe we can experiment with &:not(.full)
+// so prgoress bars won't be rounded at the opposite end until they're full?
   progress {
     @extend %progressbar_highlight;
 
     border-radius: 1.5px;
 
     &.left {
-      border-top-left-radius: 2px;
-      border-bottom-left-radius: 2px;
+      border-top-left-radius: 3px;
+      border-bottom-left-radius: 3px;
     }
 
     &.right {
-      border-top-right-radius: 2px;
-      border-bottom-right-radius: 2px;
+      border-top-right-radius: 3px;
+      border-bottom-right-radius: 3px;
     }
 
     &.top {
-      border-top-right-radius: 2px;
-      border-top-left-radius: 2px;
+      border-top-right-radius: 3px;
+      border-top-left-radius: 3px;
     }
 
     &.bottom {
-      border-bottom-right-radius: 2px;
-      border-bottom-left-radius: 2px;
+      border-bottom-right-radius: 3px;
+      border-bottom-left-radius: 3px;
     }
   }
 
@@ -3774,6 +3795,7 @@ list {
 }
 
 row {
+  outline-offset: 0;
   transition: all 150ms $ease-out-quad;
 
   &:hover { transition: none; }
@@ -3856,7 +3878,7 @@ calendar {
   &:selected {
     @extend %selected_items;
 
-    border-radius: 3px;
+    border-radius: 5px;
   }
 
   &.header {
@@ -4294,6 +4316,9 @@ colorswatch {
   &:drop(active), & { border-style: none; } // FIXME: implement a proper drop(active) state
 
   $_colorswatch_radius: 5px;
+  outline-offset: -2px;
+  -gtk-outline-radius: $_colorswatch_radius;
+
 
   // base color corners rounding
   // to avoid the artifacts caused by rounded corner anti-aliasing the base color

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -201,7 +201,7 @@
   //
     $_bg: if(lightness($c)<35%, lighten($c, 5%), $c);
     color: $tc;
-    outline-color: transparentize($tc, 0.7);
+    // outline-color: transparentize($tc, 0.7);
     background-color: $_bg;
     @if($bc == true) { border-color: if($c != $button_bg_color, _border_color($c), $borders_color); }
     @else { border-color: $_bg; }
@@ -218,7 +218,7 @@
   //
     $_bg: if(lightness($c)<35%, lighten($c, 8%), darken($c, 5%));
     color: $tc;
-    outline-color: transparentize($tc, 0.7);
+    // outline-color: transparentize($tc, 0.7);
     background-color: $_bg;
     @if($bc == true) { border-color: _border_color($_bg); }
     @else { border-color: $_bg; }
@@ -235,7 +235,7 @@
   // normal button alternative look
   //
     color: $tc;
-    outline-color: transparentize($tc, 0.7);
+    // outline-color: transparentize($tc, 0.7);
     background-color: $c;
     border-color: if($c != $button_bg_color, _border_color($c), $alt_borders_color);
     box-shadow: inset 0 -1px 0 0 $borders_edge, inset 0 2px 0 0 $borders_edge;
@@ -246,7 +246,7 @@
   // hovered button alternative look
   //
     color: $tc;
-    outline-color: transparentize($tc, 0.7);
+    // outline-color: transparentize($tc, 0.7);
     background-color: $c;
     border-color: if($c != $button_bg_color, _border_color($c), $alt_borders_color);
     box-shadow: inset 0 -1px 0 0 $borders_edge, inset 0 2px 0 0 $borders_edge;
@@ -259,7 +259,7 @@
     $_bg: if(lightness($c)<35%, darken($c, 5%), darken($c, 10%));
     //
     color: $tc;
-    outline-color: transparentize($tc, 0.7);
+    // outline-color: transparentize($tc, 0.7);
     background-color: $_bg;
     @if($bc == true) { border-color: _border_color($_bg); }
     @else { border-color: $_bg; }


### PR DESCRIPTION
- Fixes the colour mixup with the dark theme (the colour for $bg_color was meant for $base_color and vice versa)
- Uses a color for the dark fill that's closer to Suru's
- Updates $osd_bg_color (to use the proper color from the dark theme)
- Hover and active background colors for modalbuttons
- Headerbar separators use a lighter color
- Standardize use of $c and $tc instead of $_fg and $_bg
- Replaces infobar mixin with a much more sensible loop
- Update dimensions and color for popover to match suru
  
p.s this will hopefully be the last of my messy pull requests :persevere:
