### PR TITLE
Lighten headerbar separator, fix headerbar button issues when in backdrop state

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1496,7 +1496,7 @@ headerbar {
     @extend .dim-label;
   }
 
-  ~ separator, separator { background-image: image(_border_color($headerbar_bg_color)); }
+  ~ separator, separator { background-image: image(_border_color($graphite)); }
 
   & {
     // style headerbar buttons and entries using the appropriate headerbar colors
@@ -1532,17 +1532,24 @@ headerbar {
       color: $tc;
       &:backdrop { color: $backdrop_fg_color; }
 
-      @each $state, $t in (':hover', 'hover'),
+      @each $state, $t in (':not(:backdrop):hover', 'hover'),
                           (':active, &:checked', 'active'), (':disabled', 'insensitive'),
                           (':backdrop:active, &:backdrop:checked', 'backdrop-active') {
         &#{$state} { @include button($t, $c, $tc, $bc: none, $edge: none); }
+      }
+
+      &, &:backdrop {
+        &, &:disabled {
+          // headerbar buttons should be undecorated in backdrop and when disabled
+          background-color: transparent; border-color: transparent;
+        }
       }
 
       @each $b_type, $b_color in (suggested-action, $success_color),
                                   (destructive-action, $destructive_color) {
         &.#{$b_type} {
           // special buttons are not flat
-          @each $state, $t in ('', 'normal'), (':hover', 'hover'),
+          @each $state, $t in ('', 'normal'), (':not(:backdrop):hover', 'hover'),
                               (':active, &:checked', 'active'), (':backdrop', 'backdrop'),
                               (':backdrop:active, &:backdrop:checked', 'backdrop-active'),
                               (':backdrop:disabled', 'backdrop-insensitive'), (':disabled', 'insensitive') {
@@ -1566,6 +1573,7 @@ headerbar {
           $c: $headerbar_bg_color;
           $tc: $headerbar_fg_color;
           &, &:hover, &:active { @include button(normal, $c, $tc, $edge: none); }
+          &:backdrop { @include button(backdrop, $c, $tc, $edge: none); }
           @extend %underline_focus;
         }
       }
@@ -1854,7 +1862,7 @@ headerbar { // headerbar border rounding
   &:checked:not(:indeterminate) {
       font-weight: bold;
       box-shadow: inset 0 -2px $selected_bg_color;
-      &:hover { box-shadow: inset 0 -2px mix($fg_color, $selected_bg_color, 10%) }
+      &:not(:backdrop):hover { box-shadow: inset 0 -2px mix($fg_color, $selected_bg_color, 10%) }
       &:backdrop { box-shadow: inset 0 -2px _backdrop_color($selected_bg_color) }
   }
 }
@@ -4603,12 +4611,12 @@ button.titlebutton {
     $tc: $selected_fg_color;
     $edge: false;
 
-    @each $state, $t in ('', 'normal'), (':hover', 'hover'),
+    @each $state, $t in ('', 'normal'), (':hover, &:backdrop:hover', 'hover'),
     (':active', 'active'), (':disabled', 'insensitive') {
       &#{$state} { @include button($t, $c, $tc, $bc: none, $edge: none); }
     }
 
-    &:backdrop { background-color: transparent; }
+    &:backdrop { background-color: transparent; color: $backdrop_fg_color; }
   }
 
   .selection-mode & {

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1814,7 +1814,8 @@ headerbar { // headerbar border rounding
 
   &:not(:checked):not(:indeterminate) {
     color: $insensitive_fg_color;
-    &:not(:backdrop):hover { color: $headerbar_fg_color; box-shadow: inset 0 -2px $insensitive_fg_color; }
+    box-shadow: none;
+    &:not(:backdrop):hover { box-shadow: inset 0 -2px $insensitive_fg_color; }
     &:backdrop { color: $backdrop_insensitive_color; }
   }
 
@@ -1842,9 +1843,9 @@ headerbar { // headerbar border rounding
     label:first-child { padding-left: 8px; }
   }
 
-  &.text-button, &.toggle.image-button.toggle {
-    @extend %underline_focus;
+  &.text-button, &.toggle, &.toggle.image-button {
     &, &:hover, &:active, &:checked { @include button(normal); }
+    @extend %underline_focus;
     border-left-style: none;
     border-right-style: none;
   }


### PR DESCRIPTION
- Headerbar buttons now have no hover effect in backdrop unless it's a window button (close, min, max, etc.)

- Headerbar separator uses a light grey color instead of a dark black

Closes #31 #25