### PR TITLE
added 5px horizontal margin to windows controls

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4493,7 +4493,7 @@ button.titlebutton {
   border: none;
   min-width: 20px;
   min-height: 20px;
-  margin: 0;
+  margin: 0 5px;
   padding: 0;
 
   &:backdrop { color: $backdrop_fg_color; }


### PR DESCRIPTION
This commit changes windows controls from this
![image](https://user-images.githubusercontent.com/2883614/34881291-785e0846-f7b3-11e7-8cd7-5f5386f6c263.png)

to this
![image](https://user-images.githubusercontent.com/2883614/34881309-8273c3d4-f7b3-11e7-8d4b-22f67d714354.png)

closes #40 

