### PR TITLE
Flat toolbar buttons

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -528,9 +528,17 @@ button {
 
       &:hover {
         transition: $button_transition;
-        transition-duration: 500ms;
+        transition-duration: 250ms;
 
         &:active { transition: $button_transition; }
+      }
+
+      @each $state, $t in (":hover", "hover"),
+      (":active, &:checked", "active"), (":disabled", "insensitive"),
+      (":disabled:active, &:disabled:checked", "insensitive-active"), (":backdrop", "backdrop"),
+      ("backdrop:active, &:backdrop:checked", 'backdrop-active'), (":backdrop:disabled", 'backdrop-insensitive'),
+      (":backdrop:disabled:active, &:backdrop:disabled:checked", 'backdrop-insensitive-active') {
+        &#{$state} { @include button($t, $bc: none, $edge: none); }
       }
     }
 
@@ -1389,6 +1397,16 @@ toolbar {
   @extend %toolbar;
 
   padding: 4px 3px 3px 4px;
+
+  button {
+    @each $state, $t in (":hover", "hover"),
+    (":active, &:checked", "active"), (":disabled", "insensitive"),
+    (":disabled:active, &:disabled:checked", "insensitive-active"), (":backdrop", "backdrop"),
+    ("backdrop:active, &:backdrop:checked", 'backdrop-active'), (":backdrop:disabled", 'backdrop-insensitive'),
+    (":backdrop:disabled:active, &:backdrop:disabled:checked", 'backdrop-insensitive-active') {
+      &#{$state} { @include button($t, $bc: none, $edge: none); }
+    }
+  }
 
   // on OSD
   .osd & { background-color: transparent; }

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -210,7 +210,7 @@
   //
   // hovered button
   //
-    $_bg: if(lightness($c)<35%, lighten($c, 8%), darken($c, 5%));
+    $_bg: if(lightness($c)<35%, lighten($c, 8%), darken($c, 7%));
     $_bc: if($bc == true, _border_color($_bg), $_bg);
   //
     color: $tc;
@@ -245,7 +245,7 @@
   //
   // pushed button
   //
-    $_bg: if(lightness($c)<35%, darken($c, 5%), darken($c, 10%));
+    $_bg: if(lightness($c)<35%, darken($c, 5%), darken($c, 12%));
     $_bc: if($bc == true, _border_color($_bg, $darker: true), $_bg);
   //
     color: $tc;


### PR DESCRIPTION
- Toolbar buttons are flat (headerbar buttons are flat and uses no 3d effect, flat buttons outside of the headerbar now follow suit)
- Button hover and active colors are darker to accomodate for the loss of 3d effect for flat buttons