### PR TITLE
Mockups/slider switch

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2733,18 +2733,19 @@ switch {
     border-radius: 5px;
     background-clip: if($variant == "light", border-box, padding-box);
     transition: $button_transition;
+    margin: 2px;
 
     @include button(normal, white, $edge: none);
-    box-shadow: inset 0 1px 0 0 $borders_edge, inset 0 0 0 1px if($variant == "light", $borders_color, _border_color($dark_fill));
+    box-shadow: none;
   }
 
   &:hover slider { /* ?? */ } // what should this look like?
 
-  &:checked slider { box-shadow: inset 0 0 0 1px _border_color($c); }
+  //&:checked slider { box-shadow: inset 0 0 0 1px _border_color($c); }
 
   &:disabled slider {
     @include button(insensitive, if($variant == "light", white, darken(white, 60%)), $edge: none);
-    box-shadow: inset 0 0 0 1px $insensitive_borders_color;
+    //box-shadow: inset 0 0 0 1px $insensitive_borders_color;
   }
 
   &:backdrop {
@@ -2752,12 +2753,12 @@ switch {
       transition: $backdrop_transition;
 
       @include button(backdrop, white, $edge: none);
-      box-shadow: inset 0 0 0 1px $backdrop_borders_color;
+      //box-shadow: inset 0 0 0 1px $backdrop_borders_color;
     }
 
     // &:checked slider { border-color: _backdrop_color($c); }
 
-    &:disabled slider { @include button(backdrop-insensitive, if($variant == "light", white, darken(white, 60%)), $edge: none); box-shadow: inset 0 0 0 1px $backdrop_borders_color; }
+    &:disabled slider { @include button(backdrop-insensitive, if($variant == "light", white, darken(white, 60%)), $edge: none); /*box-shadow: inset 0 0 0 1px $backdrop_borders_color;*/ }
   }
 
   // row:selected & { TODO: this should theortically look fine but it should still be tested

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2725,8 +2725,8 @@ switch {
 
   slider {
     $c: $success_color;
-    min-width: 22px;
-    min-height: 24px;
+    min-width: 20px;
+    min-height: 22px;
     outline-offset: -1px;
     outline-radius: 5px;
     outline-color: $focus_color;


### PR DESCRIPTION
closes #44 

- slider completely included in switcher (2px margin from switcher border)
- switcher slightly reduced

Reduction of switcher size is limited because a too small switcher close to a bigger square button (as in Alternate tab row below), looked weird.

New version is:

checked/unchecked (in headerbar and not) 
![image](https://user-images.githubusercontent.com/2883614/34921466-f41c189e-f982-11e7-9667-6b098c6c9307.png)

same, but backdrop
![image](https://user-images.githubusercontent.com/2883614/34921473-1022b1c4-f983-11e7-8e74-12ad42790152.png)


