### PR TITLE
Update color palette, fix GNOME web trough

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -3526,6 +3526,7 @@ progressbar {
   &.osd { // progressbar.osd used for epiphany page loading progress
     min-width: 3px;
     min-height: 3px;
+    box-shadow: none;
     background-color: transparent;
 
     trough {

--- a/Communitheme/gtk-3.0/_ubuntu-colors.scss
+++ b/Communitheme/gtk-3.0/_ubuntu-colors.scss
@@ -11,12 +11,13 @@ $silk: #CCC;
 $ash: #878787;
 
 // Utility
-$red: #E9384B;
-$orange: #E55730;
+$red: #ED3146;
+$orange: #E95420;
 $yellow: #F89B0F;
-$green: #46B258;
-$blue: #30B3EA;
-$purple: #74296F;
+$green: #3EB34F;
+$blue: #19B6EE;
+$purple: #762572;
+
 
 // Terminal colors
 $terminal_base_color: #213D45;


### PR DESCRIPTION
- Update color palette
- GNOME Web's trough had a black box-shadow