### PR TITLE
Remove border-right-style on %linked-middle

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -964,6 +964,7 @@ toolbar.inline-toolbar toolbutton:backdrop {
   &:first-child {
     border-top-left-radius: 5px;
     border-bottom-left-radius: 5px;
+    border-right-style: none;
     -gtk-outline-radius: 5px 0 0 5px ;
 
   }

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -955,6 +955,7 @@ toolbar.inline-toolbar toolbutton:backdrop {
 
 %linked_middle {
   border-radius: 0;
+  border-right-style: none;
   -gtk-outline-radius: 0;
 }
 
@@ -964,7 +965,6 @@ toolbar.inline-toolbar toolbutton:backdrop {
   &:first-child {
     border-top-left-radius: 5px;
     border-bottom-left-radius: 5px;
-    border-right-style: none;
     -gtk-outline-radius: 5px 0 0 5px ;
 
   }
@@ -1567,7 +1567,7 @@ headerbar {
       }
     }
 
-    .linked button, .linked button.image-button, .horizontal.linked entry {
+    .horizontal.linked button, .horizontal.linked button.image-button, .horizontal.linked entry {
       // linked buttons are not flat
       // @each $state, $t in ("", "normal"), (":hover:not(:backdrop)", "hover"),
       // (":active, &:checked", "active"), (":disabled", "insensitive"),

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -955,7 +955,6 @@ toolbar.inline-toolbar toolbutton:backdrop {
 
 %linked_middle {
   border-radius: 0;
-  border-right-style: none;
   -gtk-outline-radius: 0;
 }
 


### PR DESCRIPTION
%linked-middle defines border-style:none only for right border, then
when it's extended in linked:first-child causes the button to shrink
when hover or backdrop

closes #69