### PR TITLE
Underline links only when hover

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1136,8 +1136,12 @@ button:visited {
 
   > label {
     @extend %link;
+  }
+
+  &:hover > label {
     text-decoration-line: underline;
   }
+
 }
 
 
@@ -2950,7 +2954,7 @@ menu menuitem, popover {
       &, &:backdrop, &:hover, &:disabled, &:backdrop:disabled { background-color: transparent; box-shadow: none; }
       &:disabled { border-color: inherit; color: inherit; }
     }
-    
+
     @each $t, $c in (':checked:not(:indeterminate)', $success_color),
                     (':indeterminate', $warning_color) {
         &#{$t} {


### PR DESCRIPTION
Moved text-decoration definition from button:link > label to
button:link:hover > label to let the link button be underlined only when
in hover state.

closes #75