### PR TITLE
Added more space between headerbar and canvas in Nautilus

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2541,6 +2541,10 @@ notebook {
 
     &:backdrop { background-color: $backdrop_base_color; }
   }
+
+  > stack grid:not(.nautilus-list-view) {
+        padding-top: 15px;
+  }
 }
 
 


### PR DESCRIPTION
Added 15px as padding-top when in grid view only.

closes #109