### PR TITLE
Removed gap in Nautilus sidebar rows

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2279,7 +2279,7 @@ popover.background {
 
   separator { margin: 3px; }
 
-  list separator { margin: 0px; }
+  list separator { margin: -1px 0px; }
 }
 
 /*************
@@ -3767,13 +3767,14 @@ list {
   color: $text_color;
   background-color: $base_color; // $sidebar_bg_color;
   border-color: $borders_color;
+  padding-top: -3px;
 
   &:backdrop {
     background-color: $backdrop_base_color; // $backdrop_sidebar_bg_color;
     border-color: $backdrop_borders_color;
   }
 
-  row { padding: 2px; }
+  row { padding: -1px 2px 2px 2px; }
 }
 
 row {
@@ -3803,6 +3804,8 @@ row {
   }
 
   &:selected { @extend %selected_items; }
+
+  row { padding: -1px 2px 2px 2px; }
 }
 
 
@@ -4033,11 +4036,13 @@ row image.sidebar-icon { opacity: $_placesidebar_icons_opacity; } // dim the sid
 
 placessidebar {
   > viewport.frame { border-style: none; }
+  > viewport > list { margin-top: -3px; }
 
   row {
     // Needs overriding of the GtkListBoxRow padding
+    margin-top: -2px;
     min-height: 36px;
-    padding: 0px;
+    padding: 1px 0px;
 
     // Using margins/padding directly in the SidebarRow
     // will make the animation of the new bookmark row jump


### PR DESCRIPTION
Removed external top margin and added some more top and bottom padding
to avoid shrinking the rows too much.

closes #108