### PR TITLE
Improve removing gaps in Nautilus sidebar

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2282,7 +2282,7 @@ popover.background {
 
   separator { margin: 3px; }
 
-  list separator { margin: -1px 0px; }
+  list separator { margin: 0px; }
 }
 
 /*************
@@ -3782,14 +3782,13 @@ list {
   color: $text_color;
   background-color: $base_color; // $sidebar_bg_color;
   border-color: $borders_color;
-  padding-top: -3px;
 
   &:backdrop {
     background-color: $backdrop_base_color; // $backdrop_sidebar_bg_color;
     border-color: $backdrop_borders_color;
   }
 
-  row { padding: -1px 2px 2px 2px; }
+  row { padding: 2px; }
 }
 
 row {
@@ -3819,8 +3818,6 @@ row {
   }
 
   &:selected { @extend %selected_items; }
-
-  row { padding: -1px 2px 2px 2px; }
 }
 
 
@@ -4051,13 +4048,14 @@ row image.sidebar-icon { opacity: $_placesidebar_icons_opacity; } // dim the sid
 
 placessidebar {
   > viewport.frame { border-style: none; }
+
   > viewport > list { margin-top: -3px; }
 
   row {
     // Needs overriding of the GtkListBoxRow padding
-    margin-top: -2px;
+    margin: -1px 0;
     min-height: 36px;
-    padding: 1px 0px;
+    padding: 0px;
 
     // Using margins/padding directly in the SidebarRow
     // will make the animation of the new bookmark row jump


### PR DESCRIPTION
This is related to #111.

CSS `padding` doesn't allow negative values. It causes `Theme parsing error`:

```
$ GTK_THEME=Communitheme gtk3-widget-factory

(gtk3-widget-factory:1175): Gtk-WARNING **: Theme parsing error: gtk.css:4610:17: negative values are not allowed.

(gtk3-widget-factory:1175): Gtk-WARNING **: Theme parsing error: gtk.css:4615:15: negative values are not allowed.

(gtk3-widget-factory:1175): Gtk-WARNING **: Theme parsing error: gtk.css:4633:15: negative values are not allowed.
```

This PR improves the code and removes the `placessidebar` gaps with less side effects.