### PR TITLE
Fix theme parsing errors

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1518,7 +1518,6 @@ headerbar {
   .title {
     padding-left: 12px;
     padding-right: 12px;
-    font-weight: 450; // same weight as shell panel button
   }
 
   .subtitle {
@@ -1863,7 +1862,6 @@ headerbar { // headerbar border rounding
   transition: 300ms ease;
   transition-property: box-shadow, color;
   &:checked, &:checked:not(:indeterminate) {
-    font-weight: 450;
     box-shadow: inset 0 -2px $selected_bg_color;
     &:backdrop { box-shadow: inset 0 -2px _backdrop_color($selected_bg_color) }
     &:not(:backdrop):hover { box-shadow: inset 0 -2px mix($selected_fg_color, $selected_bg_color, 10%) }

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -427,7 +427,7 @@
   //
     border-color: transparent;
     background-color: transparent;
-    background-image: transparent;
+    background-image: none;
     box-shadow: none;
     text-shadow: none;
     -gtk-icon-shadow: none;


### PR DESCRIPTION
This PR fixes the following theme parsing errors:

```
$ GTK_THEME=Communitheme gtk3-widget-factory

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:494:22: Not a valid image

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:649:22: Not a valid image

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:803:22: Not a valid image

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:832:24: Not a valid image

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:858:22: Not a valid image

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:941:22: Not a valid image

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:1006:22: Not a valid image

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:1089:22: Not a valid image

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:1574:20: Not a valid image

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:1588:22: Not a valid image

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:1599:22: Not a valid image

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:1609:22: Not a valid image

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:1837:17: unknown value for property

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:1973:22: Not a valid image

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:2412:24: Not a valid image

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:2665:17: unknown value for property

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:2939:22: Not a valid image

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:3112:24: Not a valid image

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:3278:22: Not a valid image

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:3286:24: Not a valid image

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:3294:24: Not a valid image

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:3302:24: Not a valid image

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:3310:24: Not a valid image

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:3318:26: Not a valid image

(gtk3-widget-factory:1976): Gtk-WARNING **: Theme parsing error: gtk.css:5366:22: Not a valid image
```

CSS `font-weight` doesn't allow such as `450` value, so simply removed those lines.

See for details about `font-weight` property: https://www.w3.org/TR/css-fonts-3/#propdef-font-weight