### PR TITLE
Bold window titles. Decrease button, entry, tab, check + radio sizes

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -257,7 +257,7 @@ spinner {
 %entry,
 entry {
   %entry_basic, & {
-    min-height: 24px;
+    min-height: 22px;
     padding: 4px 8px;
     border: 1px solid;
     border-radius: $small_radius;
@@ -511,8 +511,8 @@ $_dot_color: if($variant=='light', $selected_bg_color,
 %button,
 button {
   @at-root %button_basic, & {
-animation: shrink 1s linear infinite;
-    min-height: 24px;
+    animation: shrink 1s linear infinite;
+    min-height: 22px;
     min-width: 16px;
     padding: 4px 8px;
     border: 1px solid;
@@ -590,7 +590,7 @@ animation: shrink 1s linear infinite;
     }
 
     &.image-button {
-      min-width: 24px;
+      min-width: 22px;
       padding-left: 4px;
       padding-right: 4px;
     }
@@ -824,7 +824,7 @@ animation: shrink 1s linear infinite;
   &.font,
   &.file { separator { background-color: transparent; }}
 
-  &.font { > box > box > label { font-weight: bold; }}
+  &.font { > box > box > label { font-weight: 500; }}
 
   // inline-toolbar buttons
   .inline-toolbar &, .inline-toolbar &:backdrop {
@@ -1516,6 +1516,7 @@ headerbar {
   }
 
   .title {
+    font-weight: 500;
     padding-left: 12px;
     padding-right: 12px;
   }
@@ -1613,7 +1614,11 @@ headerbar {
       }
 
       &:hover {  box-shadow: inset 0 -2px $headerbar_insensitive_color; }
-      &:checked:not(:indeterminate) { color: $selected_fg_color; &:backdrop { color: $backdrop_headerbar_fg_color; }}
+      &:checked {
+        &, label, image {
+          color: $selected_fg_color; &:backdrop { color: $backdrop_headerbar_fg_color; }
+        }
+      }
     }
 
     %basic_underline_styling {
@@ -1731,7 +1736,7 @@ headerbar {
   .maximized &,
   .fullscreen & {
     box-shadow: inset 0 1px $inkstone;
-    
+
     &:backdrop, & {
       border-radius: 0;
     }
@@ -2053,7 +2058,7 @@ treeview.view {
   header {
     button {
       @extend %column_header_button;
-      font-weight: bold;
+      font-weight: 500;
       box-shadow: none;
 
       &:hover {
@@ -2429,8 +2434,8 @@ notebook {
     }
 
     tab {
-      min-height: 30px;
-      min-width: 30px;
+      min-height: 26px;
+      min-width: 26px;
       padding: 3px 12px;
       outline-offset: -1px; // -5px;
       color: $insensitive_fg_color;
@@ -2452,7 +2457,7 @@ notebook {
 
       &:checked {
         color: $fg_color;
-        font-weight: bold;
+        font-weight: 500;
         background-color: $base_color;
         border-color: $borders_color;
         // &.reorderable-page {
@@ -2889,7 +2894,7 @@ radio {
 
   min-height: 14px;
   min-width: 14px;
-  padding: 2px;
+  padding: 1px;
   -gtk-icon-source: none;
 
   &:backdrop { transition: $backdrop_transition; }
@@ -3308,7 +3313,7 @@ scale {
               $_scale_slider_bg_pos: bottom;
 
               @if $dir_class == 'horizontal' {
-                min-height: 26px;
+                min-height: 24px;
                 min-width: 22px;
 
                 @if $marks_infix == 'scale-has-marks-above' {
@@ -3322,7 +3327,7 @@ scale {
 
               @else {
                 min-height: 22px;
-                min-width: 26px;
+                min-width: 24px;
 
                 @if $marks_infix == 'scale-has-marks-above' {
                   margin-left: -14px;

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -411,6 +411,12 @@ entry {
     border-top-color: $borders_color;
     border-left-color: $borders_color;
     border-right-color: $borders_color;
+
+    & {
+    // buttons next to entry fields need less padding so as to not appear to wide
+    padding-left: 7px;
+    padding-right: 7px
+    }
   }
 }
 


### PR DESCRIPTION
- Fixes the issue of headerbar buttons being so large that they appear cramped
- Make window titles not blend in with flat headerbar text buttons
- Also fixes a whoopsie with checked widgets (using the underline effect) not using $selected_fg_color

Closes issue #85 
Closes issue #127