### PR TITLE
Close button red circle does not change on hover and active

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4572,7 +4572,7 @@ button.titlebutton {
     background-repeat: no-repeat;
     background-size: 20px;
 
-    @each $state, $t in ("", ""), (":hover", "-hover"), (":active", "-active"), (":backdrop", "-backdrop") {
+    @each $state, $t in ("", ""), (":backdrop", "-backdrop") {
       &#{$state} { background-image: -gtk-scaled(url("assets/close-button#{$t}.png"), url("assets/close-button#{$t}@2.png")); }
     }
   }


### PR DESCRIPTION
Window control hover and active effects affect only the button background
and the symbol (dash, cross, square) and not the red circle.

closes #137