### PR TITLE
Explicitly unset button box-shadow in flat button

### DIFF
--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -203,6 +203,9 @@
       border-bottom-color: darken($c, 30%);
       box-shadow: inset 0 -1px 1px _button_hilight_color($c);
     }
+    @else {
+      box-shadow: none;
+    }
   }
 
   @else if $t==hover {
@@ -219,6 +222,9 @@
       border-bottom-color: darken($_bg, 30%);
       box-shadow: inset 0 -1px 1px _button_hilight_color($_bg);
     }
+    @else {
+      box-shadow: none;
+    }
   }
 
   @else if $t==active {
@@ -232,9 +238,9 @@
 
     label { color: if($tc != $fg_color, mix($tc, $_bg, 80%), $tc); }
 
+    box-shadow: inset 0 2px 3px -1px $_pressed;
     @if $flat == false {
       border-color: darken($_bg, 15%);
-      box-shadow: inset 0 2px 3px -1px $_pressed;
     }
   }
 
@@ -271,6 +277,9 @@
     @if $flat==false {
       box-shadow: inset 0 -1px transparent;
     }
+    @else {
+      box-shadow: none;
+    }
   }
 
   @else if $t==insensitive {
@@ -281,7 +290,12 @@
   //
     background-color: $_bg;
     border-color: if($flat==true, $_bg, _border_color($_bg, $darker: true));
-    @if $flat==false { box-shadow: inset 0 1px 3px -1px transparentize($_pressed, .1); }
+    @if $flat==false {
+      box-shadow: inset 0 1px 3px -1px transparentize($_pressed, .1);
+    }
+    @else {
+      box-shadow: none;
+    }
   }
 
   @else if $t==backdrop {


### PR DESCRIPTION
In button mixin, box-shadow is set explicitly only in non-flat buttons.
Unsetting it explicitly on flat button too, to close issue #158 where
box-shadow appears on flat button too.

Note: button in active state needs box-shadow even if flat to have
a "pressed" effect.