### PR TITLE
Reverts the stackswitcher

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1608,7 +1608,7 @@ headerbar {
       // underline_focus using the appropriate headerbar colors
       // this is used for the stackswitcher and pathbar as there are pathbars NOT in the headerbar
       @extend %underline_focus_effect;
-      background-color: lighten($headerbar_bg_color, 10%);
+      background-color: lighten($headerbar_bg_color, 5%);
 
       &:not(:checked) {
         color: $headerbar_insensitive_color;
@@ -1616,8 +1616,10 @@ headerbar {
         &:backdrop { color: $backdrop_headerbar_insensitive_color; }
       }
 
-      &:hover {  box-shadow: inset 0 -2px $headerbar_insensitive_color; }
-      &:checked:not(:indeterminate) { color: $selected_fg_color; &:backdrop { color: $backdrop_headerbar_fg_color; }}
+      &:hover { box-shadow: inset 0 -2px $headerbar_insensitive_color; }
+      &:checked:not(:indeterminate) {
+        &, label { color: $selected_fg_color; }
+        &:backdrop { &, label { color: $backdrop_headerbar_fg_color; }}}
     }
 
     %basic_underline_styling {
@@ -1634,10 +1636,9 @@ headerbar {
     buttonbox.horizontal.linked button {
       // style the stackswitcher
       @extend %basic_underline_styling;
-      border: none;
+      background-color: transparent;
       min-width: 100px;
-      margin-left: 1px;
-      margin-right: 1px;
+      border: none;
     }
 
     .linked.path-bar button {
@@ -1650,16 +1651,15 @@ headerbar {
         &.image-button.text-button.toggle, &.text-button, &.toggle.image-button {
           // lighten($c, 5%) spits out the same bg-color as include button(normal, $headerbar_bg_color)
           // not using include button, since we don't need all the other styling
-          $c: lighten($c, 10%);
+          $c: lighten($c, 5%);
           background-color: $c;
-          border: none;
           &:disabled { background-color: darken($c, 5%); }
           &:backdrop { background-color: mix($c, $headerbar_bg_color, 50%); }
         }
 
         &.slider-button {
-            background-color: lighten($headerbar_bg_color, 5%);
-            border: none;
+            background-color: $c;
+            border: none; // specificity bump
             &:backdrop { background-color: mix($c, $headerbar_bg_color, 50%); }
         }
       }
@@ -1886,15 +1886,6 @@ headerbar { // headerbar border rounding
 }
 
 .path-bar button {
-  // keep a margin between inner buttons only
-  &.text-button {
-    margin-left: 1px;
-  }
-
-  &.slider-button:first-child {
-    margin-right: -1px;
-  }
-
   &.text-button, &.image-button, & {
     padding-left: 4px;
     padding-right: 4px;
@@ -1933,13 +1924,12 @@ headerbar { // headerbar border rounding
   }
 
   &.slider-button {
-    border-image: none;
     padding-left: 0;
     padding-right: 0;
 
     &:hover, &:active, &:disabled { background-color: $button_bg_color; }
-    &:first-child { border-radius: $medium_radius 0 0 $medium_radius; }
-    &:last-child { border-radius: 0 $medium_radius $medium_radius 0; }
+    &:first-child { border-radius: $small_radius 0 0 $small_radius; }
+    &:last-child { border-radius: 0 $small_radius $small_radius 0; }
 
     &:hover { color: $selected_bg_color; }
     &:disabled image {

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1611,12 +1611,12 @@ headerbar {
       background-color: lighten($headerbar_bg_color, 5%);
 
       &:not(:checked) {
-        color: $headerbar_insensitive_color;
-        &:hover { color: $headerbar_fg_color; }
-        &:backdrop { color: $backdrop_headerbar_insensitive_color; }
+        &, label { color: $headerbar_text_color; }
+        &:hover { &, label { color: $headerbar_fg_color; } }
+        &:backdrop { &, label { color: $backdrop_headerbar_insensitive_color; } }
       }
 
-      &:hover { box-shadow: inset 0 -2px $headerbar_insensitive_color; }
+      &:hover { box-shadow: inset 0 -2px $headerbar_text_color; }
       &:checked:not(:indeterminate) {
         &, label { color: $selected_fg_color; }
         &:backdrop { &, label { color: $backdrop_headerbar_fg_color; }}}


### PR DESCRIPTION
- The stackswitcher looks a little buggy right now so this reverts it to the old style until a decision is made on how to proceed/alter it (if even)
- Slider-buttons at the end of the path-bar use regular button radius size

![screenshot from 2018-02-14 10-02-55](https://user-images.githubusercontent.com/27529229/36208098-51ec119c-116e-11e8-99db-e84deab5c4a8.png)
