### PR TITLE
Remove treeview header button's outline-radius

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2085,6 +2085,7 @@ treeview.view {
       @extend %column_header_button;
       font-weight: 500;
       box-shadow: none;
+      -gtk-outline-radius: 0;
 
       &:hover {
         @extend %column_header_button;


### PR DESCRIPTION
Treeview header buttons are square, but they inherit the squircle outline radius from regular buttons, this commit corrects that