### PR TITLE
Limit padding-to in stack grid to Nautilus

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -32,6 +32,10 @@ list.tweak-categories separator {
                                                 // completely transparent tints the icon black
     background-image: image($selected_bg_color); // label background becomes this
   }
+
+  notebook > stack grid:not(.nautilus-list-view) {
+    padding-top: 15px;
+  }
 }
 
 .nautilus-desktop-window {

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2573,10 +2573,6 @@ notebook {
 
     &:backdrop { background-color: $backdrop_base_color; }
   }
-
-  > stack grid:not(.nautilus-list-view) {
-        padding-top: 15px;
-  }
 }
 
 


### PR DESCRIPTION
Moved fix for #109 to _apps.scss > Nautilus code to avoid messing up
with other applications.

closes #186 

Please consider also https://github.com/Ubuntu/gtk-communitheme/issues/186#issuecomment-367424861 about scroll effect in Nautilus