### PR TITLE
Fix focus ring horizontal widget in headerbar

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1591,16 +1591,18 @@ headerbar {
     }
 
     .horizontal.linked button, .horizontal.linked button.image-button, .horizontal.linked entry {
-      // @each $state, $t in ("", "normal"), (":hover:not(:backdrop)", "hover"),
-      // (":active, &:checked", "active"), (":disabled", "insensitive"),
-      // (":disabled:active, &:disabled:checked", "insensitive-active"), (":backdrop", "backdrop"),
-      // (":backdrop:active, &:backdrop:checked", 'backdrop-active'), (":backdrop:disabled", 'backdrop-insensitive'),
-      // (":backdrop:disabled:active, &:backdrop:disabled:checked", 'backdrop-insensitive-active') {
-      //   &#{$state} { @include button($t, $c, $tc, $bc: none, $flat:true); }
-      // }
-
       // force linked buttons and entries to be separate
       // this needs a lot of testing
+      &:focus {
+        & + entry { border-left-color: _border_color($graphite); }
+        & + button { border-left-color: transparent; }
+
+        & + entry,
+        & + button {
+          &:disabled { border-left-color: $insensitive_borders_color; }
+          &:backdrop { border-left-color: _border_color($headerbar_bg_color); }
+        }
+      }
       border-width: 1px;
       border-style: solid;
       -gtk-outline-radius: $small_radius;


### PR DESCRIPTION
Normally, horizontally linked widgets share right/left border, so
when the widget on the left if highlighted, also the left border of
the sibling on the right is highlighted as well.

This commit removes the logic above in headerbars, where horizontally
linked widgets are forcibly separated and do not share any border.

closes #68