### PR TITLE
Use green for selection-mode

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1690,7 +1690,7 @@ headerbar {
   }
 
   &.selection-mode {
-    $c: $neutral_color;
+    $c: $success_color;
     color: $selected_fg_color;
     border-color: _border_color($c);
     background-color: $c;
@@ -1712,12 +1712,12 @@ headerbar {
     .subtitle:link { @extend *:link:selected;  }
 
     button {
-        @each $state, $t in (":hover", "hover"),
+        @each $state, $t in ("", "normal"), (":hover", "hover"),
         (":active, &:checked", "active"), (":disabled", "insensitive"),
         (":disabled:active, &:disabled:checked", "insensitive-active"),
-        (":backdrop:active, &:backdrop:checked", 'backdrop-active'), (":backdrop:disabled", 'backdrop-insensitive'),
-        (":backdrop:disabled:active, &:backdrop:disabled:checked", 'backdrop-insensitive-active') {
-          $c: darken($neutral_color, 10%); // like the infobar
+        (":backdrop", "backdrop"), (":backdrop:active, &:backdrop:checked", 'backdrop-active'),
+        (":backdrop:disabled", 'backdrop-insensitive'), (":backdrop:disabled:active, &:backdrop:disabled:checked", 'backdrop-insensitive-active') {
+          $c: darken($success_color, 10%); // like the infobar
           $tc: white;
           &, &.selection-menu { &#{$state} { @include button($t, $c, $tc, $flat:true); } }
         }


### PR DESCRIPTION
Also fixes some buttons appearing as a regular headerbar button. See below:

![screenshot from 2018-02-26 15-43-56](https://user-images.githubusercontent.com/27529229/36691594-2e352f8e-1b0c-11e8-9b0b-e2de4373d793.png)
![screenshot from 2018-02-26 15-43-43](https://user-images.githubusercontent.com/27529229/36691595-2e537200-1b0c-11e8-86bd-838f2d7a4945.png)
