### PR TITLE
GTK2 theme now depends on adwaita and pixbuf engines

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,8 @@ Package: gtk-communitheme
 Architecture: all
 Depends: ${shlibs:Depends},
          ${misc:Depends},
+         gnome-themes-standard,
+         gtk2-engines-pixbuf,
 Description: GTK Ubuntu Community Theme
  This is the theme that is shaped by the community on the Ubuntu hub.
  .


### PR DESCRIPTION
As the GTK2 theme is based on Adwaita, it's using libadwaita + svg assets.
Ensure the package dependencies reflect this.