### PR TITLE
Fix headerbar popup buttons

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1563,7 +1563,7 @@ headerbar {
       }
     }
 
-    button, .linked button, .horizontal.linked button {
+    button, button.popup, .linked button, .horizontal.linked button {
       @each $state, $t in ("", "normal"),
                           (":hover", "hover"),
                           (":active, &:checked", "active"),


### PR DESCRIPTION
Programs that use a popup button in the headerbar (GNOME Logs, Calculator & Calendar) would use the regular button bg color instead of the headerbar button bg color

Closes issue #206