### PR TITLE
Fix GNOME Disks using dark separator in a headerbar button's menu

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -177,3 +177,13 @@ buttonbox.horizontal.linked button.toggle.toolbar-primary-buttons-software {
   // give gedit's bottom panel a border
   border-top: 1px solid $borders_color;
 }
+
+/***********
+ * GNOME Disks *
+ ***********/
+
+headerbar button image ~ window decoration ~ menu separator {
+  // gnome disks headerbar menu seems to inherit the headerbar separator bg color
+  // no unique class names or id used here so this rule is as specific as it can be
+  background: $borders_color;
+}


### PR DESCRIPTION
GNOME Disks seems to inherit a dark separator bg color from the headerbar. Since no unique classnames or ids are being used, I tried to make the rule as specific as possible so it won't affect any other program.

Closes issue #205