### PR TITLE
Remove tab hover effect in backdrop

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2463,7 +2463,7 @@ notebook {
       color: $insensitive_fg_color;
       border: 1px solid transparent;
 
-      &:hover {
+      &:hover:not(:active):not(:backdrop) {
         background-color: mix($insensitive_bg_color, $base_color, 25%);
         border-color: mix($borders_color, $base_color, 60%);
       }

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -307,6 +307,7 @@
   //
     label, & { color: if($tc != $fg_color, mix($tc, $_bg, 60%), $backdrop_fg_color); }
   //
+    -gtk-icon-effect: dim;
     box-shadow: none;
     background-color: $_bg;
     border-color: if($flat==true, $_bg, $_bc);


### PR DESCRIPTION
- Removes tab hover effect in backdrop
- Dims icons in backdrop - just barely does anything but it's better than nothing

This doesn't do anything but remove the hover effect as further discussion is being continued in  #212

Closes issue #194