### PR TITLE
Add separators to Nautilus list view

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -33,6 +33,13 @@ list.tweak-categories separator {
     background-image: image($selected_bg_color); // label background becomes this
   }
 
+  .nautilus-list-view .view {
+    border-bottom: 1px solid transparentize(black, 0.9);
+
+    // Hide superfluous treeview drop target indication
+    &.dnd { border-style: none; }
+  }
+
   notebook > stack grid:not(.nautilus-list-view) {
     padding-top: 15px;
   }


### PR DESCRIPTION
Possibly this may not look good in Communitheme. So I separated this from #233.
![image](https://user-images.githubusercontent.com/9556384/37046682-45944704-21ac-11e8-9075-23ace5151170.png)
