### PR TITLE
Update terminal colors

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -82,6 +82,8 @@ terminal-window {
           @each $state, $t in   (':hover', 'hover'), (':active, &:checked', 'active'), (':backdrop', 'backdrop'),
                                 (':backdrop:disabled', 'backdrop-insensitive'), (':disabled', 'insensitive') {
           &#{$state} { @include button($t, lighten($terminal_base_color, 3%), white, $flat:true); } }
+
+          &, &:backdrop { &, &:disabled { background-color: transparent; border-color: transparent; } }
       }
 
       &:backdrop {
@@ -111,13 +113,13 @@ terminal-window {
           color: $terminal_fg_color;
           background-color: $terminal_bg_color;
           border-color: $terminal_borders_color;
-        }
 
-        &:backdrop:checked {
-          background-color: _backdrop_color($terminal_bg_color);
-          border-color: _backdrop_color($terminal_borders_color);
-          border-bottom-color: transparent;
-          color: _backdrop_color($terminal_fg_color);
+          &:backdrop {
+            background-color: _backdrop_color($terminal_bg_color);
+            border-color: _backdrop_color($terminal_borders_color);
+            border-bottom-color: transparent;
+            color: _backdrop_color($terminal_fg_color);
+          }
         }
       }
     }

--- a/Communitheme/gtk-3.0/_ubuntu-colors.scss
+++ b/Communitheme/gtk-3.0/_ubuntu-colors.scss
@@ -24,7 +24,6 @@ $terminal_base_color: lighten($terminal_bg_color, 5%); // #213D45;
 $terminal_fg_color: white; // #5D6C71;
 $terminal_text_color: white; //#D0D7D9;
 $terminal_borders_color: darken($terminal_bg_color, 10%); // #74888D;
-$terminal_selected_bg: #102A37;
 
 // Widget Colors
 $headerbar_bg_color: #2B2929;

--- a/Communitheme/gtk-3.0/_ubuntu-colors.scss
+++ b/Communitheme/gtk-3.0/_ubuntu-colors.scss
@@ -19,11 +19,11 @@ $blue: #19B6EE;
 $purple: #762572;
 
 // Terminal colors
-$terminal_base_color: #213D45;
 $terminal_bg_color: #300A24;// #17333C;
+$terminal_base_color: lighten($terminal_bg_color, 5%); // #213D45;
 $terminal_fg_color: white; // #5D6C71;
 $terminal_text_color: white; //#D0D7D9;
-$terminal_borders_color: #74888D;
+$terminal_borders_color: darken($terminal_bg_color, 10%); // #74888D;
 $terminal_selected_bg: #102A37;
 
 // Widget Colors


### PR DESCRIPTION
The old Unity 8 terminal colors were being used in some places, this just darkens and lightens the new (purple) $terminal_bg_color for use for $terminal_borders_color and $terminal_base_color