### PR TITLE
Make buttons tied to entries narrower

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -417,8 +417,8 @@ entry {
 
     & {
       // buttons next to entry fields need less padding so as to not appear to wide
-      padding-left: 7px;
-      padding-right: 7px
+      padding-left: 6px;
+      padding-right: 6px
     }
   }
 }


### PR DESCRIPTION
I know it's a matter of opinion, but I think they look a little too wide right now.
![narrower buttons](https://user-images.githubusercontent.com/27529229/37775132-7d618e68-2db8-11e8-9b68-63038dbf9161.jpg)
