### PR TITLE
Fix gedit search field padding

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -197,6 +197,23 @@ terminal-window {
 .gedit-bottom-panel-paned ~ statusbar {
   // give gedit's bottom panel a border
   border-top: 1px solid $borders_color;
+
+    &:backdrop { border-color: $backdrop_borders_color; }
+}
+
+.gedit-search-slider {
+  // gives gedit search entry some padding and a border
+  // otherwise it's right under the headerbar
+  background: $bg_color;
+  border: 1px solid $borders_color;
+  border-top-style: none;
+  padding: 4px 8px;
+  border-radius: 0 0 5px 5px; // same radius as tooltips
+
+  &:backdrop {
+    background-color: $backdrop_bg_color;
+    border-color: $backdrop_borders_color;
+  }
 }
 
 /***********


### PR DESCRIPTION
Gives gedit search entry some padding and a border, otherwise it's right under the headerbar.

Close issue #251