### PR TITLE
Fixed terminal inactive tab hover

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -81,7 +81,7 @@ terminal-window {
         color: $terminal_fg_color;
           @each $state, $t in   (':hover', 'hover'), (':active, &:checked', 'active'), (':backdrop', 'backdrop'),
                                 (':backdrop:disabled', 'backdrop-insensitive'), (':disabled', 'insensitive') {
-          &#{$state} { @include button($t, lighten($terminal_base_color, 3%), white, $flat:true); } }
+          &#{$state} { @include button($t, lighten($terminal_base_color, 3%), white, $flat:false); } }
 
           &, &:backdrop { &, &:disabled { background-color: transparent; border-color: transparent; } }
       }
@@ -94,8 +94,13 @@ terminal-window {
       tab {
         color: $terminal_text_color;
 
+        &:hover:not(:active):not(:backdrop):not(:checked) {
+          background-color: lighten($terminal_base_color, 3%);
+          border-color: $terminal_borders_color;
+        }
+
         &:hover:not(:active):not(:backdrop) {
-          background-color: transparent;
+          background-color: $terminal_base_color;
           border-color: $terminal_borders_color;
         }
 


### PR DESCRIPTION
- replaced white background color on hover with border
- added borders to the other buttons when hover for consistency

![image](https://user-images.githubusercontent.com/2883614/37866621-760b4db2-2f8d-11e8-90aa-ddd2ac297be6.png)
