### PR TITLE
Fixed sidebar and some backdrop colors

### DIFF
--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -42,7 +42,7 @@ $osd_text_color: transparentize($osd_fg_color, .1);
 $osd_insensitive_bg_color: transparentize(mix($osd_fg_color, opacify($osd_bg_color, 1), 10%), 0.5);
 $osd_insensitive_fg_color: mix($osd_fg_color, opacify($osd_bg_color, 1), 50%);
 //
-$sidebar_bg_color: darken($bg_color, 5%); //darken(mix($bg_color, $base_color, 50%), 5%);
+$sidebar_bg_color: #F6F4F4; // This comes from darker bg_color with +2 on red channel as for headerbar to make the color warmer
 $base_hover_color: transparentize($fg_color, 0.85);
 $base_active_color: transparentize($fg_color, 0.80);
 //
@@ -58,15 +58,15 @@ $insensitive_borders_color: transparentize($borders_color, 0.6);
 
 //colors for the backdrop state, derived from the main colors.
 $backdrop_base_color: if($variant == 'light', darken($base_color, 3%), lighten($base_color, 5%));
-$backdrop_text_color: transparentize($text_color, 0.3); //mix($text_color, $backdrop_base_color, 80%);
-$backdrop_bg_color: if($variant == 'light', darken($bg_color, 5%), lighten($bg_color, 5%));
-$backdrop_fg_color: mix($fg_color, $backdrop_bg_color, 50%);
+$backdrop_text_color: transparentize($text_color, 0.2);
+$backdrop_bg_color: if($variant == 'light', darken($bg_color, 3%), lighten($bg_color, 5%));
+$backdrop_fg_color: darken($bg_color, 3%); //mix($fg_color, $backdrop_bg_color, 50%);
 $backdrop_insensitive_color: if($variant == 'light', darken($backdrop_bg_color, 15%), lighten($backdrop_bg_color, 15%));
 $backdrop_insensitive_dark_fill: $insensitive_dark_fill;
 $backdrop_selected_fg_color: if($variant == 'light', $backdrop_base_color, $backdrop_text_color);
-$backdrop_borders_color: darken($borders_color, 3%); //mix($borders_color, $bg_color, 80%);
+$backdrop_borders_color: darken($borders_color, 3%);
 $backdrop_dark_fill: if($variant == 'light', darken($dark_fill, 5%), lighten($dark_fill, 5%));
-$backdrop_sidebar_bg_color: mix($backdrop_bg_color, $backdrop_base_color, 50%);
+$backdrop_sidebar_bg_color: darken($sidebar_bg_color, 3%);
 
 $backdrop_scrollbar_bg_color: darken($backdrop_bg_color, 3%);
 $backdrop_scrollbar_slider_color: transparentize($backdrop_fg_color, 0.4);

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -3790,6 +3790,7 @@ scrolledwindow {
   viewport > list,
   viewport > stack list {
     background-color: $sidebar_bg_color;
+    &:backdrop { background-color: $backdrop_sidebar_bg_color; }
   }
   viewport.frame { // avoid double borders when viewport inside scrolled window
     border-style: none;
@@ -3848,6 +3849,12 @@ scrolledwindow {
       transition: $backdrop_transition;
     }
   }
+}
+
+// Avoid Gnome-Control-Center's language list to use sidebar colors
+frame > scrolledwindow > viewport > list {
+    background-color: white;
+    &:backdrop { background-color: $backdrop_bg_color; }
 }
 
 //vbox and hbox separators


### PR DESCRIPTION
- made sidebar color brighter and warmer
- fixed gnome-control-center language list color that was using sidebar color by mistake
- fixed some backdrop colors according to _backdrop_color function (which cannot be used directly in color.scss)