### PR TITLE
Fixed menuitem hover radius

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2202,11 +2202,16 @@ menu,
     min-height: 16px;
     min-width: 36px;
     padding: 5px 6px;
+    border-radius: 0;
     // text-shadow: none;
 
     &:hover {
       // color: $selected_fg_color;
       background-color: $base_hover_color;
+      &:first-child {
+          // first-child is the one at the bottom of the menu.
+          border-radius: 0 0 $small_radius $small_radius;
+      }
     }
 
     &:disabled {


### PR DESCRIPTION
Previously menuitem at the bottom of the menu had hover with rounded borders
on top instead of at the bottom, because menuitem at the bottom is actually a first-child.

Fixed setting appropriate border radius for first-child menuitem on hover

closes #316