### PR TITLE
Fix sidebar color

### DIFF
--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -43,7 +43,8 @@ $osd_text_color: transparentize($osd_fg_color, .1);
 $osd_insensitive_bg_color: transparentize(mix($osd_fg_color, opacify($osd_bg_color, 1), 10%), 0.5);
 $osd_insensitive_fg_color: mix($osd_fg_color, opacify($osd_bg_color, 1), 50%);
 //
-$sidebar_bg_color: #F6F4F4; // This comes from darker bg_color with +2 on red channel as for headerbar to make the color warmer
+$sidebar_bg_color: darken($bg_color, 5%);
+$sidebar_bg_color: adjust-color($sidebar_bg_color, $red: 2); // add +2 on red channel to make the color warmer like headerbar
 $base_hover_color: transparentize($fg_color, 0.85);
 $base_active_color: transparentize($fg_color, 0.80);
 //


### PR DESCRIPTION
Uses a function to warm the sidebar color instead of a hardcoded value so the dark theme wouldn't be affected. (#327)