### PR TITLE
Fix context menu border-radius on hover

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -43,6 +43,13 @@ list.tweak-categories separator {
   notebook > stack grid:not(.nautilus-list-view) {
     padding-top: 15px;
   }
+
+
+  menu menuitem:first-child:hover {
+    // context menu in nautilus has its last-child labeled as its first child lol
+    // using :hover for specificity bump
+    border-radius: 0 0 $small_radius $small_radius;
+  }
 }
 
 .nautilus-desktop-window {

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2202,12 +2202,9 @@ menu,
     // text-shadow: none;
 
     &:hover {
-      // color: $selected_fg_color;
       background-color: $base_hover_color;
-      &:first-child {
-          // first-child is the one at the bottom of the menu.
-          border-radius: 0 0 $small_radius $small_radius;
-      }
+      &:first-child { border-radius: $small_radius $small_radius 0 0; }
+      &:last-child { border-radius: 0 0 $small_radius $small_radius; }
     }
 
     &:disabled {


### PR DESCRIPTION
Not sure if the altered line was an isolated case, but it resulted in the wrong radius being used in some corners in most cases. #316 

Before:
![wrongradius](https://user-images.githubusercontent.com/27529229/38890330-0e439e30-424f-11e8-96f6-a0fca0be5e28.gif)
After:
![merge](https://user-images.githubusercontent.com/27529229/38890329-0e2c6788-424f-11e8-8b95-ea007f6ba018.gif)

