### PR TITLE
Fixed slow headerbar button backdrop transition

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -524,7 +524,6 @@ button {
     outline-color: $focus_color;
     outline-offset: -3px;
     -gtk-outline-radius: $small_radius;
-    transition: $button_transition;
 
     @include button(normal);
 


### PR DESCRIPTION
This change avoid button in headerbar to show a different timing
in backdrop transition