### PR TITLE
Selected sidebar row in nautilus icon has full opacity

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4128,7 +4128,7 @@ stacksidebar {
 /****************
  * File chooser *
  ****************/
-$_placesidebar_icons_opacity: 0.7;
+$_placesidebar_icons_opacity: 0.6;
 
 row image.sidebar-icon { opacity: $_placesidebar_icons_opacity; } // dim the sidebar icons
                                                                   // see bug #786613 for details
@@ -4190,6 +4190,7 @@ placessidebar {
 
     // in the sidebar case it makes no sense to click the selected row
     &:selected:active { box-shadow: none; }
+    &:selected image.sidebar-icon { opacity: 1; }
 
     &.sidebar-placeholder-row {
       padding: 0 8px;

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -3910,6 +3910,7 @@ row {
 
     &:backdrop { box-shadow: inset 3px 0 _backdrop_color($selected_bg_color); }
 
+    image, image.sidebar-icon { opacity: 1; }
 
     label {
       transition: padding 100ms linear;
@@ -4190,7 +4191,6 @@ placessidebar {
 
     // in the sidebar case it makes no sense to click the selected row
     &:selected:active { box-shadow: none; }
-    &:selected image.sidebar-icon { opacity: 1; }
 
     &.sidebar-placeholder-row {
       padding: 0 8px;


### PR DESCRIPTION
To have the icon be the same color as the label. Closes #364