### PR TITLE
Added dedicated mixin function for check and radio buttons

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2949,52 +2949,34 @@ radio {
 %check, %radio, check, radio {
   & {
     // for unchecked
-    @each $state, $t in ("", "normal"),
-                        (":hover", "hover"),
-                        (":active", "active") {
-                          &#{$state} {
-                            @include button($t, white, $flat:true);
-                            border: 1px solid $borders_color;
-                        }
+    @each $state, $t in ("", "normal"), (":hover", "hover"), (":active", "active") {
+      &#{$state} {
+        @include check($t, white);
+        border: 1px solid $borders_color;
+      }
     }
 
-    @each $state, $t in (":disabled", "insensitive"),
-                        (":backdrop", "backdrop"),
-                        (":backdrop:disabled", 'backdrop-insensitive') {
-                          &#{$state} {
-                            @include button($t, white, $flat:true);
-                            border: 1px solid transparentize($borders_color, 0.2);
-                          }
+    @each $state, $t in (":disabled", "insensitive"), (":backdrop", "backdrop"), (":backdrop:disabled", 'backdrop-insensitive') {
+      &#{$state} {
+        @include check($t, white);
+        border: 1px solid transparentize($borders_color, 0.2);
+      }
     }
 
     &:backdrop:disabled {
-        background: transparent;
+      background: transparent;
     }
   }
 
   & {
     // for checked
-    @each $t, $c in (':checked:not(:indeterminate)', $success_color),
-                    (':indeterminate', $success_color) {
+    @each $t, $c in (':checked:not(:indeterminate)', $success_color),(':indeterminate', $success_color) {
       &#{$t} {
-          @each $state, $t in ("", "normal"), (":hover", "hover"),
-              (":active", "active"), (":disabled", "insensitive") {
-                  &#{$state} {
-                      @include button($t, $c, white, $flat:true);
-                      border: 1px solid $c;
-                      color: white;
-                  }
-              }
-      }
-
-      &#{$t} {
-          @each $state, $t in (":backdrop", "backdrop"), (":backdrop:disabled", 'backdrop-insensitive') {
-                  &#{$state} {
-                      @include button($t, _backdrop_color($c), white, $flat:true);
-                      border: 1px solid _backdrop_color($c);
-                      color: white;
-                  }
-              }
+        @each $state, $t in ("", "normal"), (":hover", "hover"), (":disabled", "insensitive"), (":backdrop", "backdrop"), (":backdrop:disabled", 'backdrop-insensitive') {
+          &#{$state} {
+            @include check($t, $c, white);
+          }
+        }
       }
     }
   }
@@ -3017,7 +2999,6 @@ radio {
 
   &:indeterminate { -gtk-icon-source: -gtk-recolor(url("assets/dash-symbolic.symbolic.png")); }
 }
-
 
 
 // ANIMATION:

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -533,7 +533,7 @@
     background-color: transparentize($c, 0.4);
     border-color: $insensitive_borders_color;
     box-shadow: 0 1px transparent;
-    label { color: transparentize(white, 0.6); }
+    color: transparentize(white, 0.6);
   }
 
   @if $t == backdrop {
@@ -541,8 +541,7 @@
     background-color: _backdrop_color($c);
     border-color: _backdrop_color($c);
     box-shadow: none;
-
-    label, & { color: mix($tc, $c, 60%); }
+    color: mix($tc, $c, 60%);
   }
 
   @if $t==backdrop-insensitive {
@@ -550,8 +549,7 @@
     background-color: transparentize(_backdrop_color($c), 0.4);
     border-color: $insensitive_borders_color;
     box-shadow: none;
-
-    label, & { color: mix($tc, $c, 60%); }
+    color: mix($tc, $c, 60%);
   }
 }
 

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -257,24 +257,6 @@
     color: $tc;
   }
 
-  @if $t==normal-alt {
-    // normal button alternative look
-    background-color: $c;
-    border-color: _border_color($c);
-    border-top-color: darken($c, 30%);
-    box-shadow: inset 0 1px 0px 0 $borders_edge;
-    color: $tc;
-  }
-
-  @else if $t==hover-alt {
-    // hovered button alternative look
-    background-color: $c;
-    border-color: _border_color($c);
-    border-top-color: darken($c, 30%);
-    box-shadow: inset 0 1px 0px 0 $borders_edge;
-    color: $tc;
-  }
-
   @else if $t==insensitive {
     // insensitive button
     $_bg: null;
@@ -424,9 +406,6 @@
     background-color: $_bg;
     background-clip: padding-box;
     box-shadow: inset 0 -1px 1px _button_hilight_color($_bg);
-    // text-shadow: 0 1px black;
-    // -gtk-icon-shadow: 0 1px black;
-    // outline-color: transparentize($osd_fg_color, 0.7);
   }
 
   @else if $t==osd-hover {
@@ -440,9 +419,6 @@
     background-color: $_bg;
     background-clip: padding-box;
     box-shadow: inset 0 -1px 1px _button_hilight_color($_bg);
-    // text-shadow: 0 1px black;
-    // -gtk-icon-shadow: 0 1px black;
-    // outline-color: transparentize($osd_fg_color, 0.7);
   }
 
   @else if $t==osd-active {
@@ -456,9 +432,6 @@
     background-color: $_bg;
     background-clip: padding-box;
     box-shadow: inset 0 2px 3px -1px $_pressed;
-    // text-shadow: none;
-    // -gtk-icon-shadow: none;
-    // outline-color: transparentize($osd_fg_color, 0.7);
   }
 
   @else if $t==osd-insensitive {
@@ -470,8 +443,6 @@
     border-color: _border_color($osd_insensitive_bg_color);
     background-clip: padding-box;
     box-shadow: none;
-    // text-shadow: none;
-    // -gtk-icon-shadow: none;
   }
 
   @else if $t==osd-backdrop {
@@ -485,8 +456,6 @@
     background-color: $_bg;
     background-clip: padding-box;
     box-shadow: none;
-    // text-shadow: none;
-    // -gtk-icon-shadow: none;
   }
 
   @else if $t==undecorated {

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -502,6 +502,59 @@
   }
 }
 
+@mixin check($t, $c:$button_bg_color, $tc:white) {
+  // Check/Radio drawing function
+  //
+  // $t:    check/radio type,
+  // $c:    base button color for colored* types
+  // $tc:   optional text color for colored* types
+  //
+  // possible $t values:
+  // normal, hover, active, insensitive, backdrop, backdrop-insensitive
+
+  @if $t==normal  {
+    background-color: $c;
+    border-color: $c;
+    box-shadow: 0 1px transparentize(black, 0.9);
+    color: $tc;
+  }
+
+  @if $t==hover {
+    -gtk-icon-effect: highlight;
+    background-color: lighten($c, 5%);
+  }
+
+  @if $t==active {
+    box-shadow: inset 0 1px 1px 0px rgba(0, 0, 0, 0.20),
+                0 1px transparentize($c, 0.9);
+  }
+
+  @if $t==insensitive {
+    background-color: transparentize($c, 0.4);
+    border-color: $insensitive_borders_color;
+    box-shadow: 0 1px transparent;
+    label { color: transparentize(white, 0.6); }
+  }
+
+  @if $t == backdrop {
+    -gtk-icon-effect: dim;
+    background-color: _backdrop_color($c);
+    border-color: _backdrop_color($c);
+    box-shadow: none;
+
+    label, & { color: mix($tc, $c, 60%); }
+  }
+
+  @if $t==backdrop-insensitive {
+    -gtk-icon-effect: dim;
+    background-color: transparentize(_backdrop_color($c), 0.4);
+    border-color: $insensitive_borders_color;
+    box-shadow: none;
+
+    label, & { color: mix($tc, $c, 60%); }
+  }
+}
+
 @mixin overshoot($p, $t:normal, $c:$fg_color) {
 //
 // overshoot


### PR DESCRIPTION
In order to avoid interferences between changes on buttons and check/radio, this commit adds a dedicated mixin function for check/radio button that fixes #367
 
I decided to add only the "button" types we actually use in scss files: normal, hover, active, insensitive, backdrop, backdrop-insensitive, so no osd- or alt-. I assume this is safe, but not 100% sure.

Below the result
![check-radio-rework](https://user-images.githubusercontent.com/2883614/39405220-a628942a-4ba1-11e8-9637-2098d6a0ba60.gif)
 