### PR TITLE
Fixes to headerbar widget and borders

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1782,6 +1782,8 @@ headerbar {
       inset -1px 0 $inkstone;;
     }
 
+    &.selection-mode { border: none; }
+
     &:backdrop, & {
       border-radius: 0;
     }

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1723,10 +1723,22 @@ headerbar {
         (":disabled:active, &:disabled:checked", "insensitive-active"),
         (":backdrop", "backdrop"), (":backdrop:active, &:backdrop:checked", 'backdrop-active'),
         (":backdrop:disabled", 'backdrop-insensitive'), (":backdrop:disabled:active, &:backdrop:disabled:checked", 'backdrop-insensitive-active') {
-          $c: darken($success_color, 10%); // like the infobar
+          $c: $success_color; //darken($success_color, 10%); // like the infobar
           $tc: white;
-          &, &.selection-menu { &#{$state} { @include button($t, $c, $tc, $flat:true); } }
+          &, &.selection-menu {
+            &#{$state} {
+              @include button($t, $c, $tc, $flat:true);
+            }
+          }
         }
+
+      &:active, &:checked {
+        $c: darken($success_color, 10%);
+        background-color: $c;
+        box-shadow: inset 0 1px 1px 0px darken($c, 3%);
+        border-color: darken($c, 7%);
+        border-top-color: darken($c, 17%);
+      }
 
       &.flat, &.selection-menu {
         &, &:backdrop {

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1723,12 +1723,9 @@ headerbar {
         (":disabled:active, &:disabled:checked", "insensitive-active"),
         (":backdrop", "backdrop"), (":backdrop:active, &:backdrop:checked", 'backdrop-active'),
         (":backdrop:disabled", 'backdrop-insensitive'), (":backdrop:disabled:active, &:backdrop:disabled:checked", 'backdrop-insensitive-active') {
-          $c: $success_color; //darken($success_color, 10%); // like the infobar
-          $tc: white;
-          &, &.selection-menu {
-            &#{$state} {
-              @include button($t, $c, $tc, $flat:true);
-            }
+            $c: $success_color; //darken($success_color, 10%); // like the infobar
+            $tc: white;
+            &, &.selection-menu { &#{$state} { @include button($t, $c, $tc, $flat:true); }
           }
         }
 
@@ -1779,7 +1776,11 @@ headerbar {
   .tiled-left &,
   .maximized &,
   .fullscreen & {
-    box-shadow: inset 0 1px $inkstone, inset 1px 0 $inkstone;
+    &:not(.selection-mode) {
+      box-shadow: inset 0 1px $inkstone,
+      inset 1px 0 $inkstone,
+      inset -1px 0 $inkstone;;
+    }
 
     &:backdrop, & {
       border-radius: 0;

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1546,7 +1546,7 @@ headerbar {
   }
 
   &:first-child { border-right-width: 0; }
-  &:last-child { border-left-width: 0; }
+  &:dir(rtl):last-child { border-left-width: 0; }
 
   & {
     // style headerbar buttons and entries using the appropriate headerbar colors

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1723,9 +1723,12 @@ headerbar {
         (":disabled:active, &:disabled:checked", "insensitive-active"),
         (":backdrop", "backdrop"), (":backdrop:active, &:backdrop:checked", 'backdrop-active'),
         (":backdrop:disabled", 'backdrop-insensitive'), (":backdrop:disabled:active, &:backdrop:disabled:checked", 'backdrop-insensitive-active') {
-            $c: $success_color; //darken($success_color, 10%); // like the infobar
-            $tc: white;
-            &, &.selection-menu { &#{$state} { @include button($t, $c, $tc, $flat:true); }
+          $c: $success_color; //darken($success_color, 10%); // like the infobar
+          $tc: white;
+          &, &.selection-menu {
+            &#{$state} {
+              @include button($t, $c, $tc, $flat:true);
+            }
           }
         }
 
@@ -1776,11 +1779,7 @@ headerbar {
   .tiled-left &,
   .maximized &,
   .fullscreen & {
-    &:not(.selection-mode) {
-      box-shadow: inset 0 1px $inkstone,
-      inset 1px 0 $inkstone,
-      inset -1px 0 $inkstone;;
-    }
+    box-shadow: inset 0 1px $inkstone, inset 1px 0 $inkstone;
 
     &.selection-mode { border: none; }
 


### PR DESCRIPTION
- styled buttons when headerbar is in selection-mode (green buttons)
- removed black border from headerbar in selection-mode
- fixed missing left dark border in headerbar when maximized (not selection-mode)

closes #378, addresses a problem introduced with #371 