### PR TITLE
Lighter orange for selected text

### DIFF
--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -33,7 +33,7 @@ $success_color: $green;
 $destructive_color: darken($red, 10%);
 $neutral_color: $blue;
 $focus_color: transparentize($selected_bg_color, 0.4);
-$text_selection: #d2effd;
+$text_selection: #FA794B;
 //
 $osd_fg_color: $porcelain;
 $osd_bg_color: transparentize($jet, 0.3);

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4638,7 +4638,7 @@ button.titlebutton {
 
 %selected_text {
   $c: $text_selection;
-  $tc: $text_color;
+  $tc: $selected_fg_color;
   background-color: $c;
   color: $tc;
 
@@ -4646,9 +4646,9 @@ button.titlebutton {
 
   &:backdrop {
     background-color: _backdrop_color($c);
-    color: $backdrop_text_color;
+    color: $backdrop_selected_fg_color;
 
-    &:disabled { color: mix($backdrop_text_color, $c, 30%); }
+    &:disabled { color: mix($backdrop_selected_fg_color, $c, 30%); }
   }
 }
 


### PR DESCRIPTION
Uses #FA794B. 
Addresses #363. 

Seen [here](https://github.com/ubuntu/gtk-communitheme/issues/363#issuecomment-385286238).