### PR TITLE
Fixed gnome terminal backdrop color

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -73,7 +73,7 @@ terminal-window {
     color: $terminal_text_color;
 
     &:backdrop {
-      color: _backdrop_color($terminal_text_color);
+      color: $terminal_text_backdrop_color;
       background-color: _backdrop_color($terminal_bg_color);
     }
   }
@@ -118,7 +118,7 @@ terminal-window {
         }
 
         &:backdrop {
-          color: _backdrop_color($terminal_text_color);
+          &, label { color: $terminal_text_backdrop_color; }
         }
 
         &:checked {

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -70,11 +70,11 @@ terminal-window {
   .terminal-screen {
     // inherits from .background
     background-color: $terminal_bg_color;
-    color: $terminal_text_color;
+    color: $terminal_fg_color;
 
     &:backdrop {
-      color: $terminal_text_backdrop_color;
       background-color: _backdrop_color($terminal_bg_color);
+      color: $backdrop_selected_fg_color;
     }
   }
 
@@ -99,7 +99,7 @@ terminal-window {
       }
 
       tab {
-        color: $terminal_text_color;
+        color: $terminal_fg_color;
 
         &:hover:not(:active):not(:backdrop):not(:checked) {
           background-color: lighten($terminal_base_color, 3%);
@@ -118,7 +118,7 @@ terminal-window {
         }
 
         &:backdrop {
-          &, label { color: $terminal_text_backdrop_color; }
+          &, label { color: $backdrop_selected_fg_color; }
         }
 
         &:checked {
@@ -154,7 +154,7 @@ terminal-window {
         margin: 0;
         border-width: 3px;
 
-        $c: $terminal_text_color;
+        $c: $terminal_fg_color;
         background-color: transparentize($c, 0.6);
 
         &:hover {

--- a/Communitheme/gtk-3.0/_ubuntu-colors.scss
+++ b/Communitheme/gtk-3.0/_ubuntu-colors.scss
@@ -22,8 +22,6 @@ $purple: #762572;
 $terminal_bg_color: #300A24;
 $terminal_base_color: lighten($terminal_bg_color, 5%);
 $terminal_fg_color: white;
-$terminal_text_color: white;
-$terminal_text_backdrop_color: #D0D7D9;
 $terminal_borders_color: darken($terminal_bg_color, 10%);
 
 // Widget Colors

--- a/Communitheme/gtk-3.0/_ubuntu-colors.scss
+++ b/Communitheme/gtk-3.0/_ubuntu-colors.scss
@@ -19,11 +19,12 @@ $blue: #19B6EE;
 $purple: #762572;
 
 // Terminal colors
-$terminal_bg_color: #300A24;// #17333C;
-$terminal_base_color: lighten($terminal_bg_color, 5%); // #213D45;
-$terminal_fg_color: white; // #5D6C71;
-$terminal_text_color: white; //#D0D7D9;
-$terminal_borders_color: darken($terminal_bg_color, 10%); // #74888D;
+$terminal_bg_color: #300A24;
+$terminal_base_color: lighten($terminal_bg_color, 5%);
+$terminal_fg_color: white;
+$terminal_text_color: white;
+$terminal_text_backdrop_color: #D0D7D9;
+$terminal_borders_color: darken($terminal_bg_color, 10%);
 
 // Widget Colors
 $headerbar_bg_color: #2B2929;


### PR DESCRIPTION
Backdrop color of tab label was hardly visible, but at the same time
the backdrop color of terminal was a bit too bright.

Defined a new terminal_text_backdrop_color for both

closes #390