### PR TITLE
Made window top border bright

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1513,6 +1513,7 @@ headerbar {
   padding: 0 6px;
   min-height: 40px;
   border-color: transparentize(_border_color($headerbar_bg_color), 0.7);
+  border-top-color: $inkstone;
   border-style: solid;
   border-width: 1px 1px 0 1px;
   border-radius: 0;
@@ -1782,6 +1783,7 @@ headerbar {
   .tiled-left &,
   .maximized &,
   .fullscreen & {
+    border-color: transparentize(_border_color($headerbar_bg_color), 0.7);
     &.selection-mode { border: none; }
 
     &:backdrop, & {


### PR DESCRIPTION
In un-maximized mode only, added a inkstone colored window top border
to stress the idea of the light that comes from the top of the
screen.

Before
![image](https://user-images.githubusercontent.com/2883614/39672971-22265cbe-5134-11e8-8de0-6275732c15a2.png)

After
![image](https://user-images.githubusercontent.com/2883614/39672968-0f94af7e-5134-11e8-97f9-364a7af94945.png)
