### PR TITLE
Made nautilus separator line lighter

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -57,6 +57,8 @@ list.tweak-categories separator {
     // using :hover for specificity bump
     border-radius: 0 0 $small_radius $small_radius;
   }
+
+  separator, separator:backdrop { background-image: image(rgba(0, 0, 0, 0.05)); }
 }
 
 .nautilus-desktop-window {


### PR DESCRIPTION
- closes #400
- makes nautilus separator line in sidebar more similar to the one in other
  sidebars (e.g. gnome-control-center, gnome-tweaks)

![image](https://user-images.githubusercontent.com/2883614/39764916-e9dcaa1c-52e0-11e8-8346-7a5f3878cfa4.png)

