### PR TITLE
Improved selection ring in treeview and row

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -410,6 +410,14 @@ entry {
   }
 }
 
+treeview, row {
+  &:focus {
+    outline-color: transparentize(white, 0.2);
+    outline-offset: -2px;
+    -gtk-outline-radius: $small_radius;
+ }
+}
+
 treeview entry {
   &:focus {
     &:dir(rtl), &:dir(ltr) { // specificity bump hack
@@ -1551,6 +1559,7 @@ headerbar {
 
   &:first-child { border-right-width: 0; }
   &:dir(rtl):last-child { border-left-width: 0; }
+  &:dir(ltr):last-child { border-left-width: 0; }
 
   & {
     // style headerbar buttons and entries using the appropriate headerbar colors


### PR DESCRIPTION
Changed selection ring to white in focus treeview and row

When selected, treeview and row have at the same time orange background
and orange selection ring, so that the latter is not visible. Changing
the selection ring to white makes it visible again.

closes #423