### PR TITLE
box-shadow for context-menu -> readability

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4517,7 +4517,7 @@ decoration {
   .csd.popup & {
     border-radius: $small_radius;
     box-shadow: 0 2px 5px transparentize(black, 0.75),
-    0 0 0 1px transparentize($_wm_border, 0.1);
+                0 0 0 1px transparentize($_wm_border, 0.1);
   }
 
   tooltip.csd & {

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4513,10 +4513,11 @@ decoration {
   // server-side decorations as used by mutter
   .ssd & { box-shadow: none; }
 
+  //These shadows are applied to the context-menu!
   .csd.popup & {
     border-radius: $small_radius;
-    box-shadow: 0 1px 2px transparentize(black, 0.8),
-                0 0 0 1px transparentize($_wm_border, 0.1);
+    box-shadow: 0 2px 5px transparentize(black, 0.75),
+    0 0 0 1px transparentize($_wm_border, 0.1);
   }
 
   tooltip.csd & {


### PR DESCRIPTION
Fixing https://github.com/ubuntu/gtk-communitheme/issues/183#issuecomment-385289802
It's the same shadow as popovers have.

Thanks to @vinceliuice for the tip!

![image](https://user-images.githubusercontent.com/15329494/39910278-d8565794-54f6-11e8-9a83-58593d04d4ef.png)

@madsrh @clobrano is this okay for you?