### PR TITLE
Refine gnome terminal

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -95,11 +95,24 @@ terminal-window {
 
       button.flat {
         color: $terminal_fg_color;
-        @each $state, $t in   (':hover', 'hover'), (':active, &:checked', 'active'), (':backdrop', 'backdrop'),
-        (':backdrop:disabled', 'backdrop-insensitive'), (':disabled', 'insensitive') {
-        &#{$state} { @include button($t, darken($headerbar_bg_color, 5%), white, $flat:false); } }
+        @each $state, $t in (':hover', 'hover'),
+                            (':active, &:checked', 'active'),
+                            (':backdrop', 'backdrop'),
+                            (':backdrop:disabled', 'backdrop-insensitive'),
+                            (':disabled', 'insensitive') {
+            &#{$state} {
+              @include button($t, $headerbar_bg_color, $headerbar_bg_color, $flat:true);
+              color: white;
+            }
+        }
 
-        &, &:backdrop { &, &:disabled { background-color: transparent; border-color: transparent; } }
+        &:backdrop { color: $backdrop_headerbar_fg_color; }
+        &, &:backdrop {
+          &, &:disabled {
+            background-color: transparent;
+            border-color: transparent;
+          }
+        }
       }
 
       &:backdrop {

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -127,8 +127,9 @@ terminal-window {
 
         &:hover:not(:active):not(:backdrop):not(:checked) {
           background-color: $headerbar_bg_color;
+          background-color: lighten($headerbar_bg_color, 4%);
           border-color: $_border_color;
-          border-bottom-color: $inkstone;
+          border-color: $inkstone;
         }
 
         &:hover:not(:active):not(:backdrop) {

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -82,6 +82,7 @@ terminal-window {
   notebook > header.top > tabs > tab {
     &:checked {
       color: $terminal_fg_color;
+      border-color: $inkstone;
       border-bottom: 2px solid darken($orange, 10%);
     }
   }
@@ -89,7 +90,7 @@ terminal-window {
   notebook {
     // inherits from notebook header
     > header {
-      border-color: $terminal_borders_color;
+      border-color: $inkstone;
       background-color: $headerbar_bg_color;
 
       button.flat {
@@ -107,21 +108,24 @@ terminal-window {
       }
 
       tab {
+        $_border_color: transparentize(_border_color($menubar_bg_color), 0.8);
+
         color: $ash;
 
         &:hover:not(:active):not(:backdrop):not(:checked) {
-          background-color: $headerbar_bg_color; //lighten($headerbar_bg_color, 3%);
-          border-color: $terminal_borders_color;
+          background-color: $headerbar_bg_color;
+          border-color: $_border_color;
+          border-bottom-color: $inkstone;
         }
 
         &:hover:not(:active):not(:backdrop) {
           background-color: $headerbar_bg_color;
-          border-color: $terminal_borders_color;
+          border-color: $_border_color;
         }
 
         &:hover:checked:not(:backdrop) {
-          background-color: $hb_button_bg_hover;
-          border-color: $terminal_borders_color;
+          background-color: lighten($headerbar_bg_color, 6%);
+          border-color: $inkstone;
           border-bottom: 2px solid $orange;
         }
 
@@ -131,12 +135,12 @@ terminal-window {
 
         &:checked {
           color: $terminal_fg_color;
-          background-color: lighten($headerbar_bg_color, 5%);
-          border-color: $terminal_borders_color;
+          background-color: lighten($headerbar_bg_color, 4%);
+          border-color: $_border_color;
 
           &:backdrop {
             background-color: $backdrop_headerbar_bg_color;
-            border-color: _backdrop_color($terminal_borders_color);
+            border-color: _backdrop_color($_border_color);
             border-bottom-color: transparent;
             color: _backdrop_color($terminal_fg_color);
           }
@@ -146,7 +150,7 @@ terminal-window {
 
     scrollbar {
       // inherits from scrollbar
-      $_scrollbar_bg: darken($terminal_bg_color, 5%);
+      $_scrollbar_bg: darken($headerbar_bg_color, 5%);
       $_scrollbar_bc: darken($terminal_borders_color, 5%);
       background-color: $_scrollbar_bg;
       border-color: $_scrollbar_bc;

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2170,13 +2170,15 @@ treeview.view {
 menubar,
 .menubar {
   -GtkWidget-window-dragging: true;
+  $_border_color: _border_color($menubar_bg_color);
+
   background-color: $menubar_bg_color;
-  box-shadow: inset 0 -1px _border_color($menubar_bg_color);
+  border-color: transparentize($_border_color, 0.8);
+  border-style: solid;
+  border-width: 0 1px;
+  box-shadow: inset 0 -1px transparentize($_border_color, 0.8);
   color: $headerbar_text_color;
   padding: 0px;
-  border-width: 0 1px;
-  border-color: transparentize(_border_color($headerbar_bg_color), 0.7);
-  border-style: solid;
 
   &:backdrop {
     background-color: $backdrop_menubar_bg_color; color: $backdrop_headerbar_text_color;

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2181,7 +2181,8 @@ menubar,
   padding: 0px;
 
   &:backdrop {
-    background-color: $backdrop_menubar_bg_color; color: $backdrop_headerbar_text_color;
+    background-color: $backdrop_headerbar_bg_color;
+    color: $backdrop_headerbar_text_color;
     & label { color: $backdrop_fg_color; }
   }
 


### PR DESCRIPTION
As per review of #410 

- fixed flat dark button style
- added bright border to active/checked tab
- fixed menubar backdrop color (this is a bonus. If this PR does not get merged, cherry-pick this commit as well)

![gnome-terminal-review](https://user-images.githubusercontent.com/2883614/39965536-5ed0351a-569b-11e8-8f55-4dd68ab58ab3.gif)
