### PR TITLE
move_bradius_&_background_color_to_csdpopup

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -44,12 +44,6 @@ list.tweak-categories separator {
     margin-right: 9px;
   }
 
-  menu menuitem:first-child:hover {
-    // context menu in nautilus has its last-child labeled as its first child lol
-    // using :hover for specificity bump
-    border-radius: 0 0 $small_radius $small_radius;
-  }
-
   separator, separator:backdrop { background-image: image(rgba(0, 0, 0, 0.05)); }
 }
 

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4505,9 +4505,6 @@ decoration {
     box-shadow: 0 2px 5px transparentize(black, 0.75),
                 0 0 0 1px transparentize($_wm_border, 0.1);
   }
-  .background.csd.popup & {
-    border-radius: 0 0 $small_radius $small_radius;
-  }
 
   tooltip.csd & {
     border-radius: 5px;

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2209,10 +2209,10 @@ menu,
 .context-menu {
   margin: 4px; // see https://bugzilla.gnome.org/show_bug.cgi?id=591258
   // padding: 2px;
-  background-color: $menu_color;
+  background-color: transparent;//$menu_color;
   color: $text_color;
   border: 1px solid $borders_color; // adds borders in a non composited env
-  border-radius: $small_radius;
+  border-radius: 0px;//$small_radius;
 
   .csd & { border: none; }  // axes borders in a composited env
 
@@ -4513,6 +4513,7 @@ decoration {
   //These shadows are applied to the context-menu!
   .csd.popup & {
     border-radius: $small_radius;
+    background-color: $menu_color;
     box-shadow: 0 2px 5px transparentize(black, 0.75),
                 0 0 0 1px transparentize($_wm_border, 0.1);
   }

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2208,7 +2208,7 @@ menu,
 .menu,
 .context-menu {
   margin: 4px; // see https://bugzilla.gnome.org/show_bug.cgi?id=591258
-  // padding: 2px;
+  padding: 3px 0;
   background-color: transparent;//$menu_color;
   color: $text_color;
   border: 1px solid $borders_color; // adds borders in a non composited env
@@ -2228,8 +2228,6 @@ menu,
 
     &:hover {
       background-color: $base_hover_color;
-      &:first-child { border-radius: $small_radius $small_radius 0 0; }
-      &:last-child { border-radius: 0 0 $small_radius $small_radius; }
     }
 
     &:disabled {
@@ -2241,16 +2239,6 @@ menu,
     &:backdrop:hover {
       color: $backdrop_fg_color;
       background-color: transparent;
-    }
-
-    &:first-child {
-      border-top-right-radius: $small_radius;
-      border-top-left-radius: $small_radius;
-    }
-
-    &:last-child {
-      border-bottom-right-radius: $small_radius;
-      border-bottom-left-radius: $small_radius;
     }
 
     // submenu indicators

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2208,7 +2208,7 @@ menu,
 .menu,
 .context-menu {
   margin: 4px; // see https://bugzilla.gnome.org/show_bug.cgi?id=591258
-  padding: 3px 0;
+  padding: 4px 0;
   background-color: transparent;//$menu_color;
   color: $text_color;
   border: 1px solid $borders_color; // adds borders in a non composited env
@@ -4498,12 +4498,15 @@ decoration {
   // server-side decorations as used by mutter
   .ssd & { box-shadow: none; }
 
-  //These shadows are applied to the context-menu!
+  //These shadows and border-radius are applied to the context-menu 's
   .csd.popup & {
     border-radius: $small_radius;
     background-color: $menu_color;
     box-shadow: 0 2px 5px transparentize(black, 0.75),
                 0 0 0 1px transparentize($_wm_border, 0.1);
+  }
+  .background.csd.popup & {
+    border-radius: 0 0 $small_radius $small_radius;
   }
 
   tooltip.csd & {


### PR DESCRIPTION
This fixes the firefox border-radius bleed, by cutting the border-radius (other themes use this way to avoid firefox's problem with round edges, too :|) but keeps the border-radius for regular GTK context-menus
![image_2018-05-13_13-06-48](https://user-images.githubusercontent.com/15329494/39966780-b72e6d9c-56b1-11e8-8ab6-b5a9ed02956c.png)
So this closes https://github.com/ubuntu/gtk-communitheme/issues/431

But this also brings border radius back for non-csd menus on all 4 edges
like in mypaint
![image_2018-05-13_13-07-17](https://user-images.githubusercontent.com/15329494/39966782-bc0adbb6-56b1-11e8-8cad-c2d50796c288.png)


@clobrano @godlyranchdressing @madsrh @CraigD is this okay for you? I personally feel the cut of borders look weird anyways. But I could imagine that some think the other way! 

