### PR TITLE
Make icons less bright in backdrop

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -13,7 +13,7 @@ list.tweak-categories separator {
 .nautilus-window {
   // keep details box visible
   // details box looks ugly when many items are selected and it floats above the orange
-  *scrolledwindow:backdrop { opacity: 0.85; }
+  *scrolledwindow:backdrop { opacity: 0.9; }
    // Makes icons less bright in backdrop
   paned box.floating-bar {
     background: $bg_color;

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -13,7 +13,7 @@ list.tweak-categories separator {
 .nautilus-window {
   // keep details box visible
   // details box looks ugly when many items are selected and it floats above the orange
-  *scrolledwindow:backdrop { opacity: 0.95; }
+  *scrolledwindow:backdrop { opacity: 0.94; }
    // Makes icons less bright in backdrop
   paned box.floating-bar {
     background: $bg_color;

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -13,6 +13,8 @@ list.tweak-categories separator {
 .nautilus-window {
   // keep details box visible
   // details box looks ugly when many items are selected and it floats above the orange
+  *scrolledwindow:backdrop { opacity: 0.95; }
+   // Makes icons less bright in backdrop
   paned box.floating-bar {
     background: $bg_color;
     border: 1px solid $borders_color;
@@ -62,8 +64,6 @@ list.tweak-categories separator {
   }
 }
 
-// Makes icons less bright in backdrop
-*scrolledwindow:backdrop { opacity: 0.95; }
 
 /***********
  * Terminal *

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -13,7 +13,7 @@ list.tweak-categories separator {
 .nautilus-window {
   // keep details box visible
   // details box looks ugly when many items are selected and it floats above the orange
-  *scrolledwindow:backdrop { opacity: 0.94; }
+  *scrolledwindow:backdrop { opacity: 0.85; }
    // Makes icons less bright in backdrop
   paned box.floating-bar {
     background: $bg_color;

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -62,6 +62,9 @@ list.tweak-categories separator {
   }
 }
 
+// Makes icons less bright in backdrop
+*scrolledwindow:backdrop { opacity: 0.95; }
+
 /***********
  * Terminal *
  ***********/


### PR DESCRIPTION
I don't know if the wildcard is considered a hacky solution.
Make icons in Nautilus less bright in backdrop.