### PR TITLE
darktheme introduction and light theme improvements

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -265,3 +265,20 @@ headerbar button image ~ window decoration ~ menu separator {
   // no unique class names or id used here so this rule is as specific as it can be
   background: $borders_color;
 }
+
+/***********
+ * GNOME ToDo *
+ ***********/
+
+taskrow.activatable.new-task-row button.popup.toggle {
+  border-radius: 0px;
+  border: none;
+  border-left: 1px solid $borders-color;
+  padding-left: 10px; padding-right: 10px;
+
+}
+
+viewport.view, listbox.transparent {
+  background-color: $sidebar_bg_color;
+  &:backdrop { background-color: $backdrop_sidebar_bg_color;}
+}

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -299,13 +299,13 @@ headerbar button image ~ window decoration ~ menu separator {
 
   toolitem box widget * {
     // reset toolbar button dimensions
-    min-height: 0; 
+    min-height: 0;
     min-width: 0;
   }
 
-  .linked button { 
+  .linked button {
     // link linked buttons
-    margin-right: 0; 
+    margin-right: 0;
   }
 
     button {
@@ -322,5 +322,25 @@ headerbar button image ~ window decoration ~ menu separator {
                             &#{$state} { @include button($t) }
       }
     }
+  }
+}
+
+/***********
+* GNOME ToDo *
+***********/
+
+.org-gnome-Todo {
+  taskrow.activatable.new-task-row button.popup.toggle {
+   border-radius: 0px;
+   border: none;
+   border-left: 1px solid $borders-color;
+   padding-left: 10px; padding-right: 10px;
+   -gtk-outline-radius: 0;
+
+  }
+
+  viewport.view, listbox.transparent {
+   background-color: $sidebar_bg_color;
+   &:backdrop { background-color: $backdrop_sidebar_bg_color;}
   }
 }

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -275,6 +275,7 @@ taskrow.activatable.new-task-row button.popup.toggle {
   border: none;
   border-left: 1px solid $borders-color;
   padding-left: 10px; padding-right: 10px;
+  -gtk-outline-radius: 0;
 
 }
 

--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -6,7 +6,7 @@
 $base_color: if($variant == 'light', #FFFFFF, $inkstone);
 $bg_color: if($variant == 'light', #FAFAFA, $inkstone);
 $fg_color: if($variant == 'light', $inkstone, $porcelain);
-$text_color: if($variant == 'light', #2D2D2D, $silk);
+$text_color: if($variant == 'light', #2D2D2D, $porcelain);
 //
 $selected_fg_color: #ffffff;
 $selected_bg_color: $orange;

--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -4,7 +4,7 @@
 @import 'ubuntu-colors';
 
 $base_color: if($variant == 'light', #FFFFFF, $inkstone);
-$bg_color: if($variant == 'light', #FAFAFA, darken($inkstone,5%));
+$bg_color: if($variant == 'light', #FAFAFA, darken($inkstone,1%));
 $fg_color: if($variant == 'light', $inkstone, $porcelain);
 $text_color: if($variant == 'light', #2D2D2D, $porcelain);
 //

--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -43,7 +43,7 @@ $osd_text_color: transparentize($osd_fg_color, .1);
 $osd_insensitive_bg_color: transparentize(mix($osd_fg_color, opacify($osd_bg_color, 1), 10%), 0.5);
 $osd_insensitive_fg_color: mix($osd_fg_color, opacify($osd_bg_color, 1), 50%);
 //
-$sidebar_bg_color: darken($bg_color, 5%);
+$sidebar_bg_color: if($variant == 'light', darken($bg_color, 5%), lighten($bg_color, 5%));
 $sidebar_bg_color: adjust-color($sidebar_bg_color, $red: 2); // add +2 on red channel to make the color warmer like headerbar
 $base_hover_color: transparentize($fg_color, 0.85);
 $base_active_color: transparentize($fg_color, 0.80);

--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -3,8 +3,8 @@
 
 @import 'ubuntu-colors';
 
-$base_color: if($variant == 'light', #FFFFFF, #292933);
-$bg_color: if($variant == 'light', #FAFAFA, #1C1B21);
+$base_color: if($variant == 'light', #FFFFFF, $inkstone);
+$bg_color: if($variant == 'light', #FAFAFA, $inkstone);
 $fg_color: if($variant == 'light', $inkstone, $porcelain);
 $text_color: if($variant == 'light', #2D2D2D, $silk);
 //

--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -61,14 +61,14 @@ $insensitive_borders_color: transparentize($borders_color, 0.4);
 //colors for the backdrop state, derived from the main colors.
 $backdrop_base_color: if($variant == 'light', darken($base_color, 5%), lighten($base_color, 5%));
 $backdrop_text_color: transparentize($text_color, 0.2);
-$backdrop_bg_color: if($variant == 'light', darken($bg_color, 3%), lighten($bg_color, 5%));
+$backdrop_bg_color: if($variant == 'light', darken($bg_color, 3%), lighten($bg_color, 1%));
 $backdrop_fg_color: mix($fg_color, $backdrop_bg_color, 50%);
 $backdrop_insensitive_color: if($variant == 'light', darken($backdrop_bg_color, 15%), lighten($backdrop_bg_color, 15%));
 $backdrop_insensitive_dark_fill: $insensitive_dark_fill;
 $backdrop_selected_fg_color: if($variant == 'light', $backdrop_base_color, $backdrop_text_color);
-$backdrop_borders_color: darken($borders_color, 3%);
+$backdrop_borders_color: if($variant == 'light',darken($borders_color, 3%), lighten($borders_color, 3%));
 $backdrop_dark_fill: if($variant == 'light', darken($dark_fill, 5%), lighten($dark_fill, 5%));
-$backdrop_sidebar_bg_color: darken($sidebar_bg_color, 3%);
+$backdrop_sidebar_bg_color: if($variant == 'light',darken($sidebar_bg_color, 3%), lighten($sidebar_bg_color, 1%));
 
 $backdrop_scrollbar_bg_color: darken($backdrop_bg_color, 3%);
 $backdrop_scrollbar_slider_color: transparentize($backdrop_fg_color, 0.4);

--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -4,7 +4,7 @@
 @import 'ubuntu-colors';
 
 $base_color: if($variant == 'light', #FFFFFF, $inkstone);
-$bg_color: if($variant == 'light', #FAFAFA, $inkstone);
+$bg_color: if($variant == 'light', #FAFAFA, darken($inkstone,5%));
 $fg_color: if($variant == 'light', $inkstone, $porcelain);
 $text_color: if($variant == 'light', #2D2D2D, $porcelain);
 //

--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -10,7 +10,7 @@ $text_color: if($variant == 'light', #2D2D2D, $porcelain);
 //
 $selected_fg_color: #ffffff;
 $selected_bg_color: $orange;
-$borders_color: if($variant == 'light', darken($bg_color, 18%), darken($bg_color, 10%));
+$borders_color: if($variant == 'light', darken($bg_color, 18%), darken($bg_color, 7%));
 $link_color: $blue;
 $link_visited_color: if($variant == 'light', darken($link_color, 20%), lighten($link_color, 10%));
 $borders_edge: rgba(0, 0, 0, 0.1);

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1690,6 +1690,11 @@ headerbar {
 
         margin: 0;
         border: none;
+
+        &:insensitive:checked{
+          background-color: $hb_pathbar_bg;
+          &:backdrop{ background-color: $hb_pathbar_bg_backdrop;}
+        }
       }
     }
 

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2156,12 +2156,12 @@ treeview.view {
   border-style: none solid solid none;
   border-color: $borders_color; // don't darken the bottom border color
   border-radius: 0;
-  background-color: $sidebar_bg_color;
+  background-color: $bg_color;
 
   &:backdrop {
     border-style: none solid solid none;
     border-color: $backdrop_borders_color;
-    background-color: $backdrop_sidebar_bg_color;
+    background-color: $backdrop_bg_color;
   }
 
   &:last-child { &:backdrop, & { border-right-style: none; }}

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4134,6 +4134,12 @@ placessidebar {
 }
 
 placesview {
+
+  > stack > frame > scrolledwindow > viewport > list {
+    background-color: $bg_color;
+    &:backdrop { background-color: $backdrop_bg_color; }
+  }
+
   .server-list-button > image {
     transition: 200ms $ease-out-quad;
     -gtk-icon-transform: rotate(0turn);
@@ -4144,13 +4150,15 @@ placesview {
     -gtk-icon-transform: rotate(-0.5turn);
   }
 
-  row.activatable:hover { background-color: transparent; }
+  row.activatable:hover { background-color: transparent; }im
 
   // this selects the "connect to server" label
   > actionbar > revealer > box > label {
     padding-left: 8px;
     padding-right: 8px;
   }
+
+
 }
 
 

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4451,11 +4451,11 @@ colorchooser .popover.osd { border-radius: 5px; }
  ********/
 //content view (grid/list)
 .content-view {
-  background-color: darken($bg_color,7%);
+  background-color: $bg_color;
 
   &:hover { -gtk-icon-effect: highlight; }
 
-  &:backdrop { background-color: $bg_color,7%; }
+  &:backdrop { background-color: $backdrop_bg_color; }
 
   rubberband, .rubberband { @extend rubberband; }
 }

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4455,7 +4455,7 @@ colorchooser .popover.osd { border-radius: 5px; }
 
   &:hover { -gtk-icon-effect: highlight; }
 
-  &:backdrop { background-color: darken($bg_color,7%); }
+  &:backdrop { background-color: $bg_color,7%; }
 
   rubberband, .rubberband { @extend rubberband; }
 }

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2004,6 +2004,7 @@ treeview.view {
 
   border-left-color: mix($fg_color, $base_color, 50%); // this is actually the tree lines color,
   border-top-color: transparentize(black, 0.9);        // while this is the grid lines color, better then nothing
+  background-color: $base_color;
 
   rubberband { @extend rubberband; } // to avoid borders being overridden by the previously set props
 
@@ -2041,6 +2042,7 @@ treeview.view {
   &:backdrop {
     border-left-color: mix($backdrop_fg_color, $backdrop_bg_color, 50%);
     border-top: transparentize(black, 0.9);
+    background-color: $backdrop_bg_color;
   }
   &:drop(active) {
     border-style: solid none;
@@ -2154,9 +2156,12 @@ treeview.view {
   border-style: none solid solid none;
   border-color: $borders_color; // don't darken the bottom border color
   border-radius: 0;
+  background-color: $sidebar_bg_color;
 
   &:backdrop {
     border-style: none solid solid none;
+    border-color: $backdrop_borders_color;
+    background-color: $backdrop_sidebar_bg_color;
   }
 
   &:last-child { &:backdrop, & { border-right-style: none; }}
@@ -3959,9 +3964,11 @@ filechooser {
 
     background: $_bg;
     border-bottom: 1px solid $borders_color;
+    &:backdrop{background:  $backdrop_sidebar_bg_color;}
 
     .path-bar.linked button {
       background: darken($_bg, 5%);
+      &:backdrop { background: $_bg}
       &, & label { color: $text_color }
 
       &:backdrop label { color: $backdrop_text_color; }

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4036,7 +4036,7 @@ stacksidebar {
 /****************
  * File chooser *
  ****************/
-$_placesidebar_icons_opacity: 0.6;
+$_placesidebar_icons_opacity: 0.8;
 
 row image.sidebar-icon { opacity: $_placesidebar_icons_opacity; } // dim the sidebar icons
                                                                   // see bug #786613 for details


### PR DESCRIPTION
@madsrh @clobrano please test the dark version with apps that use the dark theme by default like
GNOME
videos ("totem")
eye of gnome (that picture viewer)
boxes (virtualization software)
peek
todo (if you activate the dark theme in appmenu-> extensions)

Updating the gifs and pictures with every commit to be up to date:

Filechooser:
![image](https://user-images.githubusercontent.com/15329494/40272257-ecfbcb2e-5baa-11e8-89a2-9539a2d2f694.png)
![filechooser](https://user-images.githubusercontent.com/15329494/40272259-f03e866e-5baa-11e8-84c3-82c51078a0ed.gif)

Boxes:
![image](https://user-images.githubusercontent.com/15329494/40272300-56bdd566-5bab-11e8-8314-66f2263a8e41.png)
![boxes](https://user-images.githubusercontent.com/15329494/40272301-590a5e52-5bab-11e8-8d7b-d5babf5c499e.gif)

Eye of gnome (image viewer):
![image](https://user-images.githubusercontent.com/15329494/40272321-a8b9cea6-5bab-11e8-897b-b6b889d34452.png)
![eog](https://user-images.githubusercontent.com/15329494/40272322-ac3181c8-5bab-11e8-9c35-280159067273.gif)

Pitivi:
![image](https://user-images.githubusercontent.com/15329494/40272343-02019ee4-5bac-11e8-89b8-006582bfd2d8.png)
![pitivi](https://user-images.githubusercontent.com/15329494/40272345-0477c950-5bac-11e8-84d9-33e5426282bc.gif)

Todo:
![image](https://user-images.githubusercontent.com/15329494/40272460-935fc5f4-5bad-11e8-87a5-6341e62c06c6.png)
![todo](https://user-images.githubusercontent.com/15329494/40272461-95d6de8a-5bad-11e8-92aa-1cc9cc4b9a6d.gif)


