### PR TITLE
Fix check + radio backdrop

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2880,23 +2880,12 @@ radio {
 
 %check, %radio, check, radio {
   & {
+    border: 1px solid;
     // for unchecked
-    @each $state, $t in ("", "normal"), (":hover", "hover"), (":active", "active") {
+    @each $state, $t in ("", "normal"), (":hover", "hover"), (":active", "active"), (":disabled", "insensitive"), (":backdrop", "backdrop"), (":backdrop:disabled", 'backdrop-insensitive') {
       &#{$state} {
         @include check($t, white);
-        border: 1px solid $borders_color;
       }
-    }
-
-    @each $state, $t in (":disabled", "insensitive"), (":backdrop", "backdrop"), (":backdrop:disabled", 'backdrop-insensitive') {
-      &#{$state} {
-        @include check($t, white);
-        border: 1px solid transparentize($borders_color, 0.2);
-      }
-    }
-
-    &:backdrop:disabled {
-      background: transparent;
     }
   }
 

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -481,7 +481,7 @@
   }
 }
 
-@mixin check($t, $c:$button_bg_color, $tc:white) {
+@mixin check($t, $c:white, $tc:white) {
   // Check/Radio drawing function
   //
   // $t:    check/radio type,
@@ -491,10 +491,12 @@
   // possible $t values:
   // normal, hover, active, insensitive, backdrop, backdrop-insensitive
 
+  $_border: if($c == white, $borders_color, $c);
+
   @if $t==normal  {
     background-color: $c;
-    border-color: $c;
-    box-shadow: 0 1px transparentize(black, 0.9);
+    border-color: $_border;
+    box-shadow: 0 1px transparentize(black, 0.95);
     color: $tc;
   }
 
@@ -504,31 +506,33 @@
   }
 
   @if $t==active {
-    box-shadow: inset 0 1px 1px 0px rgba(0, 0, 0, 0.20),
-                0 1px transparentize($c, 0.9);
+    box-shadow: inset 0 1px 1px 0px rgba(0, 0, 0, 0.1);
   }
 
   @if $t==insensitive {
-    background-color: transparentize($c, 0.4);
-    border-color: $insensitive_borders_color;
-    box-shadow: 0 1px transparent;
-    color: transparentize(white, 0.6);
+    $_bg: mix($c, $base_color, 50%);
+    background-color: $_bg;
+    border-color: if($c==white, $insensitive_borders_color, $_bg);
+    box-shadow: none;
+    color: transparentize($tc, 0.4);
   }
 
   @if $t == backdrop {
+    $_bg: mix($c, $base_color, 85%);
     -gtk-icon-effect: dim;
-    background-color: _backdrop_color($c);
-    border-color: _backdrop_color($c);
+    background-color: _backdrop_color($_bg);
+    border-color: if($c==white, $insensitive_borders_color, _backdrop_color($_bg));
     box-shadow: none;
-    color: mix($tc, $c, 60%);
+    color: transparentize($tc, 0.5);
   }
 
   @if $t==backdrop-insensitive {
+    $_bg: mix(_backdrop_color($c), $base_color, 60%);
     -gtk-icon-effect: dim;
-    background-color: transparentize(_backdrop_color($c), 0.4);
-    border-color: $insensitive_borders_color;
+    background-color: $_bg;
+    border-color: if($c==white, $insensitive_borders_color, $_bg);
     box-shadow: none;
-    color: mix($tc, $c, 60%);
+    color: transparentize($tc, 0.6);
   }
 }
 


### PR DESCRIPTION
Fixes some quirks like green checks using the gray $insensitive_borders_color, also lessens the box-shadow for regular buttons.

Before:
![checks1](https://user-images.githubusercontent.com/27529229/40129490-6b9c2ef2-5902-11e8-8c9d-178a0ea2f2e3.gif)
After:
![check2](https://user-images.githubusercontent.com/27529229/40129491-6bba8802-5902-11e8-878a-99b2552c9581.gif)
