### PR TITLE
Fix focus ring cut label text

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -162,6 +162,7 @@ flowbox {
 
 label {
   caret-color: currentColor; // this shouldn't be needed.
+  outline-offset: 1px;
 
   &.separator {
     @extend .dim-label;
@@ -1781,8 +1782,6 @@ headerbar {
         }
       }
     }
-
-
   }
 
   // squared corners when the window is maximized, tiled, or fullscreen


### PR DESCRIPTION
Current focus ring on label is too tight and "cut" the text.
Increased outline-offset (-3px -> +1px) to avoid that.

closes #458 

![image](https://user-images.githubusercontent.com/2883614/40233520-a12877c2-5aa3-11e8-9848-e9698f94bd27.png)
