### PR TITLE
Separator finetune + close button in backdrop fix

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -13,7 +13,7 @@ list.tweak-categories separator {
 .nautilus-window {
   // keep details box visible
   // details box looks ugly when many items are selected and it floats above the orange
-  *scrolledwindow:backdrop { opacity: 0.9; }
+  *scrolledwindow:backdrop { opacity: 0.9; } // what is this for?
    // Makes icons less bright in backdrop
   paned box.floating-bar {
     background: $bg_color;
@@ -36,7 +36,7 @@ list.tweak-categories separator {
   }
 
   .nautilus-list-view .view {
-    border-bottom: 1px solid transparentize(black, 0.9);
+    border-bottom: 1px solid transparentize($borders_color, 0.8);
 
     // Hide superfluous treeview drop target indication
     &.dnd { border-style: none; }
@@ -52,8 +52,14 @@ list.tweak-categories separator {
     border-radius: 0 0 $small_radius $small_radius;
   }
 
-  separator, separator:backdrop { background-image: image(rgba(0, 0, 0, 0.05)); }
+  paned > separator{
+    // separator between sidebar and main window view
+    &, &:backdrop {
+      background-image: image($borders_color);
+    }
+  }
 }
+
 
 .nautilus-desktop-window {
   .nautilus-desktop.view {

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1546,11 +1546,14 @@ headerbar {
   }
 
   ~ separator, separator {
-    background-image: image(mix($inkstone, $headerbar_bg_color, 50%));
-    &:backdrop {
-      background-image: image(mix($inkstone, $headerbar_bg_color, 20%));
+    &, &.titlebutton {
+      &.horizontal, &.vertical { 
+        & { background-image: image(mix($inkstone, $headerbar_bg_color, 50%)); }
+        &:backdrop { background-image: image(mix(darken($inkstone, 5%), $backdrop_headerbar_bg_color, 50%)); }
+      }
     }
   }
+
 
   &:not(:only-child):first-child { border-right-width: 0; }
   &:not(:only-child):not(:first-child) { border-left-width: 0; };
@@ -2001,7 +2004,7 @@ treeview.view {
    }
 
   border-left-color: mix($fg_color, $base_color, 50%); // this is actually the tree lines color,
-  border-top-color: transparentize(black, 0.9);        // while this is the grid lines color, better then nothing
+  border-top-color: transparentize($borders_color, 0.8);        // while this is the grid lines color, better then nothing
   background-color: $base_color;
 
   rubberband { @extend rubberband; } // to avoid borders being overridden by the previously set props
@@ -2015,7 +2018,7 @@ treeview.view {
 
     &:backdrop, & {
       border-left-color: mix($selected_fg_color, $selected_bg_color, 50%);
-      border-top-color: transparentize(black, 0.9); // doesn't work unfortunatelly
+      border-top-color: transparentize($borders_color, 0.8); // doesn't work unfortunatelly
     }
   }
 
@@ -2039,7 +2042,7 @@ treeview.view {
 
   &:backdrop {
     border-left-color: mix($backdrop_fg_color, $backdrop_bg_color, 50%);
-    border-top: transparentize(black, 0.9);
+    border-top-color: transparentize($borders_color, 0.8);
     background-color: $backdrop_bg_color;
   }
   &:drop(active) {
@@ -2118,16 +2121,6 @@ treeview.view {
       font-weight: 500;
       box-shadow: none;
       -gtk-outline-radius: 0;
-
-      &:hover {
-        @extend %column_header_button;
-        transition: none;
-      }
-
-      &:active {
-        @extend %column_header_button;
-        transition: none;
-      }
     }
   }
 
@@ -2154,12 +2147,10 @@ treeview.view {
   border-style: none solid solid none;
   border-color: $borders_color; // don't darken the bottom border color
   border-radius: 0;
-  background-color: $bg_color;
 
   &:backdrop {
     border-style: none solid solid none;
     border-color: $backdrop_borders_color;
-    background-color: $backdrop_bg_color;
   }
 
   &:last-child { &:backdrop, & { border-right-style: none; }}
@@ -3755,16 +3746,22 @@ scrolledwindow {
 
 // Avoid Gnome-Control-Center's language list to use sidebar colors
 frame > scrolledwindow > viewport > list {
-    background-color: white;
+    background-color: /*white*/ $bg_color; 
     &:backdrop { background-color: $backdrop_bg_color; }
+
 }
 
 //vbox and hbox separators
 separator {
-  background: transparentize(black, 0.9);
+  background: transparentize(/*black*/$borders_color, 0.9); 
   min-width: 1px;
   min-height: 1px;
 }
+
+// box > separator.vertical { 
+  // target separators between sidebars and views -> this may need to be a thing
+  // background: $borders_color;
+// }
 
 
 /*********
@@ -3781,6 +3778,11 @@ list {
   }
 
   row { padding: 2px; }
+
+  separator { 
+    // separator within sidebar 
+    background-color: transparentize($borders_color, 0.5);
+  }
 }
 
 row {
@@ -3879,9 +3881,9 @@ calendar {
   }
 
   &.header {
-    border-bottom-color: transparentize(black, 0.9);
+    border-bottom-color: $borders_color;
 
-    &:backdrop { border-bottom-color: transparentize(black, 0.9); }
+    &:backdrop { border-bottom-color: $borders_color; }
   }
 
   &.button {
@@ -3967,7 +3969,8 @@ filechooser {
 
   & actionbar { background-color: $sidebar_bg_color; }
   & placessidebar ~ box box > stack ~ box  {
-    background-color: #efeded;
+    // what is this for?
+    background-color: #efeded; // fixed color won't work with dark theme
     border: 1px solid rgba(0, 0, 0, 0.2);
     border-width: 0 1px;
     padding: 10px;
@@ -4054,6 +4057,11 @@ placessidebar {
   > viewport.frame { border-style: none; }
 
   > viewport > list { margin-top: -3px; }
+
+  separator { 
+    // separator within sidebar 
+    background-color: transparentize($borders_color, 0.5);
+  }
 
   row {
     // Needs overriding of the GtkListBoxRow padding
@@ -4583,7 +4591,6 @@ button.titlebutton {
     @include draw_circle($selected_bg_color, $close:true);
   }
 }
-
 
 // catch all extend :)
 

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -3930,6 +3930,8 @@ messagedialog { // Message Dialog styling
 }
 
 filechooser {
+  background-color: white;
+
   .dialog-action-box {
     border-top: 1px solid $borders_color;
 
@@ -3950,13 +3952,20 @@ filechooser {
       &:checked label { font-weight: 500; }
     }
   }
+
+  & actionbar { background-color: $sidebar_bg_color; }
+  & placessidebar ~ box box > stack ~ box  {
+    background-color: #efeded;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    border-width: 0 1px;
+    padding: 10px;
+  }
 }
 
 filechooserbutton:drop(active) {
   box-shadow: none;
   border-color: transparent;
 }
-
 
 /***********
  * Sidebar *

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -777,7 +777,7 @@ $circle_size: 20px / $button_size / 2;
 
 @if $close == true {
   &:backdrop {
-    color: $headerbar_fg_color;
+    color: $backdrop_headerbar_fg_color;
     &:backdrop:hover {
       $_bg: lighten($headerbar_bg_color, 25%);
       background-image: -gtk-gradient(radial,


### PR DESCRIPTION
Closes #453

Also makes the close button in backdrop have the same color as the other titlebuttons instead of white.

Before on the left, after on the right:
![trans2](https://user-images.githubusercontent.com/27529229/40282605-d5e84440-5c3f-11e8-970a-13d5dc357866.png)

Also adjusts headerbar separator so it's more visible. Before on the left, after on the right:
![b4af](https://user-images.githubusercontent.com/27529229/40282616-3329f77a-5c40-11e8-84fc-1d3b45b6571d.png)
