### PR TITLE
Fixed misalignment for small title button in chromium/chrome

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -331,9 +331,9 @@ headerbar button image ~ window decoration ~ menu separator {
   }
 }
 
-/***********
+/*************
 * GNOME ToDo *
-***********/
+**************/
 
 .org-gnome-Todo {
   taskrow.activatable.new-task-row button.popup.toggle {
@@ -348,5 +348,25 @@ headerbar button image ~ window decoration ~ menu separator {
   viewport.view, listbox.transparent {
    background-color: $sidebar_bg_color;
    &:backdrop { background-color: $backdrop_sidebar_bg_color;}
+  }
+}
+
+/*********************
+ * Chrome / Chromium *
+ *********************/
+window.maximized.background.chromium {
+  button.titlebutton {
+    padding: 0;
+
+    &, &:hover, &:active {
+      headerbar &, .titlebar &, & {
+        // spec bump otherwise :backdrop  will still have a bg
+        &, &:backdrop { @extend %undecorated_button; }
+      }
+    }
+    &:not(.close):not(.appmenu){
+      &:hover { @include draw_circle($headerbar_bg_color, $size:20px) ; }
+    }
+    &.close { @include draw_circle($selected_bg_color, $close:true, $size:20px); }
   }
 }

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -761,8 +761,8 @@
   box-shadow: none;
 }
 
-@mixin draw_circle($c, $close:false) {
-$button_size: 24px + 2px * 2;
+@mixin draw_circle($c, $close:false, $size:24px) {
+$button_size: $size + 2px * 2;
 $circle_size: 20px / $button_size / 2;
 
   background-image: -gtk-gradient(radial,


### PR DESCRIPTION
This issue appeared on chromium/chrome only, therefore specific code as been
written in _apps.scss. Chrome is a widely used application, therefore I consider
this a valid exception to our idea of not-app-specific changes.
Moreover, the change is basically an implementation of "small/smaller titlebutton"
that might turn out useful for other applications in the future.

closes #412 

Before
![image](https://user-images.githubusercontent.com/2883614/40547670-cfeedc10-6032-11e8-954c-d3018bb34247.png)

After the fix
![image](https://user-images.githubusercontent.com/2883614/40547628-bda845b4-6032-11e8-8607-dd76149cf625.png)
