### PR TITLE
placessidebar_transparentize_selected_row

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4088,7 +4088,7 @@ placessidebar {
     &:backdrop {
       color: $backdrop_text_color;
 
-      // &:selected { color: $backdrop_selected_fg_color; }
+       &:selected { background-color: transparentize($selected_bg_color,0.2); }
 
       &:disabled { color: $backdrop_insensitive_color; }
     }
@@ -4261,7 +4261,7 @@ infobar {
       selection { background-color: darken($c, 10%); }
 
       &:backdrop, & {
-        color: $selected_fg_color; 
+        color: $selected_fg_color;
         border-color: _border_color($c);
       }
 

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4088,7 +4088,7 @@ placessidebar {
     &:backdrop {
       color: $backdrop_text_color;
 
-       &:selected { background-color: transparentize($selected_bg_color,0.2); }
+       &:selected { background-color: transparentize($selected_bg_color,0.1); }
 
       &:disabled { color: $backdrop_insensitive_color; }
     }


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/15329494/40589157-c2da1f8c-61e8-11e8-8046-e551c180e01d.gif)
After:
![after](https://user-images.githubusercontent.com/15329494/40589160-c885d62e-61e8-11e8-902d-6dec674b4ea4.gif)

I think this is needed because the pure orange distracts too much. @madsrh what do you think?