### PR TITLE
Fix GTK warnings as insensitive is deprecated

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1709,7 +1709,7 @@ headerbar {
         margin: 0;
         border: none;
 
-        &:insensitive:checked{
+        &:disabled:checked{
           background-color: $hb_pathbar_bg;
           &:backdrop{ background-color: $hb_pathbar_bg_backdrop;}
         }


### PR DESCRIPTION
This fixes some deprecation warnings spamming the CLI (which isn't the case for upstream Adwaita):

Example starting gedit:
(gedit:11641): Gtk-WARNING **: 10:41:20.935: Theme parsing error: gtk.css:2672:72: The :insensitive pseudo-class is deprecated. Use :disabled instead.
(gedit:11641): Gtk-WARNING **: 10:41:20.935: Theme parsing error: gtk.css:2673:66: The :insensitive pseudo-class is deprecated. Use :disabled instead.
(gedit:11641): Gtk-WARNING **: 10:41:20.935: Theme parsing error: gtk.css:2674:57: The :insensitive pseudo-class is deprecated. Use :disabled instead.
(gedit:11641): Gtk-WARNING **: 10:41:20.935: Theme parsing error: gtk.css:2675:51: The :insensitive pseudo-class is deprecated. Use :disabled instead.
(gedit:11641): Gtk-WARNING **: 10:41:20.935: Theme parsing error: gtk.css:2677:74: The :insensitive pseudo-class is deprecated. Use :disabled instead.
(gedit:11641): Gtk-WARNING **: 10:41:20.935: Theme parsing error: gtk.css:2678:68: The :insensitive pseudo-class is deprecated. Use :disabled instead.
(gedit:11641): Gtk-WARNING **: 10:41:20.935: Theme parsing error: gtk.css:2679:59: The :insensitive pseudo-class is deprecated. Use :disabled instead.
(gedit:11641): Gtk-WARNING **: 10:41:20.935: Theme parsing error: gtk.css:2680:53: The :insensitive pseudo-class is deprecated. Use :disabled instead.
