### PR TITLE
Silk backdrop selection

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -47,12 +47,6 @@ list.tweak-categories separator {
     margin-right: 9px;
   }
 
-  menu menuitem:first-child:hover {
-    // context menu in nautilus has its last-child labeled as its first child lol
-    // using :hover for specificity bump
-    border-radius: 0 0 $small_radius $small_radius;
-  }
-
   paned > separator{
     // separator between sidebar and main window view
     &, &:backdrop {
@@ -366,4 +360,5 @@ window.background.chromium {
       @include draw_circle($selected_bg_color, $close:true, $size:20px);
     }
   }
+  menuitem { border-radius: 0; }
 }

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -363,3 +363,8 @@ window.background.chromium {
   }
   menuitem { border-radius: 0; }
 }
+
+/*********************
+ * Geary *
+ *********************/
+.geary-conversation-frame scrolledwindow:backdrop * { color: $backdrop_text_color;}

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -33,6 +33,7 @@ list.tweak-categories separator {
                                                 // near transparent white results in no tint
                                                 // completely transparent tints the icon black
     background-image: image($selected_bg_color); // label background becomes this
+    &:backdrop {background-image: image($backdrop_selected_bg_color);}
   }
 
   .nautilus-list-view .view {

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -34,6 +34,7 @@ list.tweak-categories separator {
                                                 // completely transparent tints the icon black
     background-image: image($selected_bg_color); // label background becomes this
     &:backdrop {background-image: image($backdrop_selected_bg_color);}
+    border-radius: $small_radius;
   }
 
   .nautilus-list-view .view {

--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -67,6 +67,7 @@ $backdrop_fg_color: mix($fg_color, $backdrop_bg_color, 50%);
 $backdrop_insensitive_color: if($variant == 'light', darken($backdrop_bg_color, 15%), lighten($backdrop_bg_color, 15%));
 $backdrop_insensitive_dark_fill: $insensitive_dark_fill;
 $backdrop_selected_fg_color: if($variant == 'light', $backdrop_base_color, $backdrop_text_color);
+$backdrop_selected_bg_color: if($variant == 'light', $silk, $graphite);
 $backdrop_borders_color: if($variant == 'light',darken($borders_color, 3%), lighten($borders_color, 3%));
 $backdrop_dark_fill: if($variant == 'light', darken($dark_fill, 5%), lighten($dark_fill, 5%));
 $backdrop_sidebar_bg_color: if($variant == 'light',darken($sidebar_bg_color, 3%), lighten($sidebar_bg_color, 1%));

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4618,8 +4618,8 @@ button.titlebutton {
   &:disabled { color: mix($tc, $c, 50%); }
 
   &:backdrop {
-    background-color: if($variant==light,lighten($c,5%),darken($c,5%));
-    color: $slate;//$backdrop_selected_fg_color;
+    background-color: $backdrop_selected_bg_color;
+    color: $backdrop_text_color;
 
     &:disabled { color: mix($backdrop_selected_fg_color, $c, 30%); }
   }

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -252,7 +252,7 @@ assistant {
 spinner {
   background: none;
   opacity: 0; // non spinning spinner makes no sense
-  color: $blue;
+  color: $orange; //$blue;
   -gtk-icon-source: -gtk-icontheme('process-working-symbolic');
 
   &:checked {
@@ -1709,7 +1709,7 @@ headerbar {
         margin: 0;
         border: none;
 
-        &:insensitive:checked{
+        &:disabled:checked{
           background-color: $hb_pathbar_bg;
           &:backdrop{ background-color: $hb_pathbar_bg_backdrop;}
         }
@@ -2225,7 +2225,7 @@ menu,
 .menu,
 .context-menu {
   margin: 4px; // see https://bugzilla.gnome.org/show_bug.cgi?id=591258
-  // padding: 2px;
+  padding: 4px;
   background-color: $menu_color;
   color: $text_color;
   border: 1px solid $borders_color; // adds borders in a non composited env
@@ -2240,14 +2240,10 @@ menu,
     min-height: 16px;
     min-width: 36px;
     padding: 5px 6px;
-    border-radius: 0;
+    border-radius: $small_radius;
     // text-shadow: none;
 
-    &:hover {
-      background-color: $base_hover_color;
-      &:first-child { border-radius: $small_radius $small_radius 0 0; }
-      &:last-child { border-radius: 0 0 $small_radius $small_radius; }
-    }
+    &:hover { background-color: $base_hover_color; }
 
     &:disabled {
       color: $insensitive_fg_color;
@@ -2260,32 +2256,14 @@ menu,
       background-color: transparent;
     }
 
-    &:first-child {
-      border-top-right-radius: $small_radius;
-      border-top-left-radius: $small_radius;
-    }
-
-    &:last-child {
-      border-bottom-right-radius: $small_radius;
-      border-bottom-left-radius: $small_radius;
-    }
-
     // submenu indicators
     arrow {
       min-height: 16px;
       min-width: 16px;
 
-      &:dir(ltr) {
-        -gtk-icon-source: -gtk-icontheme('pan-end-symbolic');
-        margin-left: 10px;
-        margin-right: 10px;
-      }
+      &:dir(ltr) { -gtk-icon-source: -gtk-icontheme('pan-end-symbolic'); }
 
-      &:dir(rtl) {
-        -gtk-icon-source: -gtk-icontheme('pan-end-symbolic-rtl');
-        margin-right: 10px;
-        margin-left: 10px;
-      }
+      &:dir(rtl) { -gtk-icon-source: -gtk-icontheme('pan-end-symbolic-rtl'); }
     }
 
     // avoids labels color being overridden, see
@@ -3169,9 +3147,10 @@ scale {
 
   slider {
     $c: $neutral_color;
+    $_bc: _border_color($dark_fill);
     @include button(normal, white);
 
-    border: 1px solid _border_color($dark_fill);
+    border: 1px solid $_bc;
     border-radius: 10px;
     background-clip: if($variant == "light", border-box, padding-box);
     transition: $button_transition;
@@ -3181,7 +3160,10 @@ scale {
 
     &:active { border-color: _border_color($c); }
 
-    &:disabled { @include button(insensitive, if($variant == "light", white, darken(white, 20%))); }
+    &:disabled {
+      @include button(insensitive, if($variant == "light", white, darken(white, 20%)));
+      border-color: lighten($_bc, 10%);
+    }
 
     &:backdrop {
       transition: $backdrop_transition;

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1681,7 +1681,7 @@ headerbar {
 
         &:checked {
           color: $backdrop_headerbar_fg_color;
-          box-shadow: inset 0 -2px _backdrop_color($selected_bg_color);
+          box-shadow: inset 0 -2px $backdrop_selected_bg_color;
         }
       }
     }
@@ -1969,7 +1969,7 @@ headerbar { // headerbar border rounding
     border-color: transparent;
     box-shadow: inset 0 -2px transparent;
 
-    &:checked { box-shadow: inset 0 -2px _backdrop_color($selected_bg_color); }
+    &:checked { box-shadow: inset 0 -2px $backdrop_selected_bg_color; }
   }
 
   &.text-button, &.image-button, & {
@@ -4612,7 +4612,7 @@ button.titlebutton {
   $tc: $selected_fg_color;
   background-color: $c;
 
-  &:backdrop { background-color: _backdrop_color($c); }
+  &:backdrop { background-color: $backdrop_selected_bg_color;}
 
   @at-root %nobg_selected_items, & {
     color: $tc;
@@ -4620,7 +4620,7 @@ button.titlebutton {
     &:disabled { color: mix($tc, $c, 50%); }
 
     &:backdrop {
-      &, label { color: $backdrop_selected_fg_color; }
+      &, label { color: $backdrop_text_color; }
 
       &:disabled { color: mix($backdrop_selected_fg_color, $c, 30%); }
     }


### PR DESCRIPTION
Use silk instead of orange for the backdrop selection in several places as shown at the bottom of [this issue]( https://github.com/ubuntu/gtk-communitheme/issues/212#issuecomment-393887091) :
- nautilus icon view labels
- sidebar rows in setting, tweaks, nautilus, etc.
- treeview row selection

@madsrh (and anyone else) please try this PR and share your feelings :dancer: 