### PR TITLE
Use flat buttons in toolbar only if explicitly defined by developer

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1439,7 +1439,7 @@ toolbar {
 
   padding: 4px 3px 3px 4px;
 
-  button {
+  button.flat {
     @each $state, $t in ("", "normal"), (":hover", "hover"),
     (":active, &:checked", "active"), (":disabled", "insensitive"),
     (":disabled:active, &:disabled:checked", "insensitive-active"), (":backdrop", "backdrop"),


### PR DESCRIPTION
closes #493