### PR TITLE
bring_back_blue_spinner

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -252,7 +252,7 @@ assistant {
 spinner {
   background: none;
   opacity: 0; // non spinning spinner makes no sense
-  color: $orange; //$blue;
+  color: $blue;
   -gtk-icon-source: -gtk-icontheme('process-working-symbolic');
 
   &:checked {


### PR DESCRIPTION
That's a regression, gtk process working spinner was orange for some commits. 
Fixed it back to blue:
![erfsfgsdfgd](https://user-images.githubusercontent.com/15329494/41006575-5fd271aa-6922-11e8-9648-f075951ef581.gif)
