### PR TITLE
Fixed gedit and menu issues

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -262,6 +262,7 @@ terminal-window {
 .gedit-search-entry-occurrences-tag {
     color: transparentize($fg_color, 0.65);
     border: none; // Removed ugly tag border
+    box-shadow: none; // Removed button inset shadow
     margin: 2px;
     padding: 2px;
 }

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -259,6 +259,39 @@ terminal-window {
   }
 }
 
+.gedit-search-entry-occurrences-tag {
+    color: transparentize($fg_color, 0.65);
+    border: none; // Removed ugly tag border
+    margin: 2px;
+    padding: 2px;
+}
+
+.gedit-document-panel { // 'documents' pane
+
+    row.activatable { padding: 6px; }
+
+    row button { // 'close' button
+        min-width: 22px;
+        min-height: 22px;
+        padding: 0;
+        margin: 0;
+        border: none;
+    }
+
+    row:hover button {
+        &:hover {
+            background-color: rgba($fg_color, 0.15);
+        }
+        &:active {
+            background-color: rgba($fg_color, 0.25);
+        }
+    }
+
+    row:hover:selected button:hover {
+        color: $selected_fg_color;
+    }
+}
+
 /***********
  * GNOME Disks *
  ***********/

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2290,7 +2290,7 @@ menu,
     }
 
     &.bottom {
-      // margin-bottom: -6px;
+      margin-bottom: -8px;
       border-top: 1px solid mix($fg_color, $base_color, 10%);
       border-bottom-right-radius: $small_radius;
       border-bottom-left-radius: $small_radius;
@@ -2319,8 +2319,10 @@ menuitem {
   }
 }
 
-window.background:not(.csd) { // firefox menu
-  .menu { border: none; }
+window.background:not(.csd) {
+  // Firefox menu
+  > menu, .menu { border: none; } // Removed ugly menu borders
+  > menu > menuitem { border-radius: 0; } // Removed rounded menu corners
 }
 
 /***************

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2205,6 +2205,9 @@ menubar,
 
     menu {
       border-radius: 0 0 $small_radius $small_radius;
+      menu {
+        border-radius: $small_radius;
+      }
     }
 
     &:hover { //Seems like it :hover even with keyboard focus


### PR DESCRIPTION
1. Fixed gedit Document panel row close button color issues
2. Removed gedit-search-entry-occurrences-tag ugly border
3. Removed firefox rounded menu corners
4. Removed menu overflow arrow button extra space