### PR TITLE
Transparent background for pictures in GNOME Photos

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -361,3 +361,9 @@ window.background.chromium {
   }
   menuitem { border-radius: 0; }
 }
+
+/*********************
+ * GNOME Photos *
+ *********************/
+//.documents-scrolledwin {background-color: black;}
+.documents-scrolledwin.frame.frame widget flowboxchild.tile { background-color: transparent; }

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -365,5 +365,5 @@ window.background.chromium {
 /*********************
  * GNOME Photos *
  *********************/
-//.documents-scrolledwin {background-color: black;}
+//removes the black background for picture tiles 
 .documents-scrolledwin.frame.frame widget flowboxchild.tile { background-color: transparent; }


### PR DESCRIPTION
Closes https://github.com/ubuntu/gtk-communitheme/issues/243

