### PR TITLE
Light orange for text, ubuntu orange for entries

### DIFF
--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -34,7 +34,7 @@ $success_color: $green;
 $destructive_color: darken($red, 10%);
 $neutral_color: $blue;
 $focus_color: transparentize($selected_bg_color, 0.4);
-$text_selection: #C4E4F0; // #FA794B;
+$text_selection: rgba(#c83703, 0.24);
 //
 $osd_fg_color: $porcelain;
 $osd_bg_color: transparentize($jet, 0.3);

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4610,7 +4610,7 @@ button.titlebutton {
 
 %selected_text {
   $c: $text_selection;
-  $tc: if($variant==light,$text_color,#2D2D2D);
+  $tc: $text_color;
   background-color: $c;
   color: $tc;
 

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -315,8 +315,7 @@ entry {
     &:backdrop:disabled { @include entry(backdrop-insensitive); }
 
     selection {
-      // @extend %selected_items;
-      @extend %selected_text; //Trying blue for the text selection
+      @extend %selected_items;
     }
 
     // entry error and warning style


### PR DESCRIPTION
- libreoffice has some hardcoded text selection color
- adapt the text selection to that
- EXCEPT gtkentries, which use regular ubuntu orange
![image](https://user-images.githubusercontent.com/15329494/41068374-6f344340-69e9-11e8-9098-6beef18c1bf5.png)

This is a test PR for  @madsrh and for everyone who has too much time! ;D