### PR TITLE
Differentiate between checked and unchecked disabled switch

### DIFF
--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -589,6 +589,10 @@
     background-color: if($bg==$dark_fill, transparent, $ash);
     border: 1px solid $borders_edge;
     box-shadow: none;
+
+    &:checked {
+      background-color: transparentize($dark_fill, 0.7);
+    }
   }
 
   &:backdrop {


### PR DESCRIPTION
When in insensitive/disabled state there is no difference between
checked and unchecked switches.

closes #238 

![image](https://user-images.githubusercontent.com/2883614/41101398-4f6b94f2-6a64-11e8-8208-6b384a62c92d.png)
