### PR TITLE
Lighten the orange in backdrop

### DIFF
--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -4,7 +4,7 @@
 
 @function _backdrop_color($c) {
   // adjusts colors for use in the backdrop state
-  // colors are darkened when using the dark theme so they aren't such a light grey
+  // colors are lightened for both light and dark, the level may be changed later
   @if $variant != 'light' {
     @return lighten($c, 5%);
   }

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -6,10 +6,11 @@
   // adjusts colors for use in the backdrop state
   // colors are darkened when using the dark theme so they aren't such a light grey
   @if $variant != 'light' {
-    $c: darken($c, 7.5%);
+    @return lighten($c, 5%);
   }
-  //@return transparentize(desaturate($c, 75%), .4);
-  @return darken($c, 3%);
+  @else {
+    @return lighten($c, 5%);
+  }
 }
 
 // @function _widget_edge($c:$borders_edge) {


### PR DESCRIPTION
Continuation of the discussions here: https://github.com/ubuntu/gtk-communitheme/pull/508
And here: https://github.com/ubuntu/gtk-communitheme/issues/212#issuecomment-393887091

Closes https://github.com/ubuntu/gtk-communitheme/issues/212

@clobrano @madsrh I still think the grey has a better usability but this one looks better =)

![bs2](https://user-images.githubusercontent.com/15329494/41153872-67ca8a6c-6b18-11e8-9208-0bdcbc063393.gif)
![bs1](https://user-images.githubusercontent.com/15329494/41153873-67e47f80-6b18-11e8-930b-cdb9e85dd843.gif)

![screenshot from 2018-06-08 12-28-02](https://user-images.githubusercontent.com/15329494/41153886-73a5f9de-6b18-11e8-93a3-f8337b7352db.png)
![screenshot from 2018-06-08 12-27-18](https://user-images.githubusercontent.com/15329494/41153887-741bdc08-6b18-11e8-9b73-1753116e7a3d.png)
