### PR TITLE
sidebar colors tweaks

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -62,11 +62,11 @@ list.tweak-categories separator {
     &:backdrop { background-color: $backdrop_bg_color; }
 
     & > tab {
-      border-bottom: 1px solid transparentize($borders_color, 0.6);
+      border-bottom: 1px solid transparentize($borders_color, 0.5);
       margin: 0px;
 
       &:checked {
-        border-color: transparentize($borders_color, 0.6);
+        border-color: transparentize($borders_color, 0.5);
         border-bottom: none;
 
         &:backdrop { background-color: #EEEFF0; }  // It should be _backdrop_color(white); but that does not work.

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -13,8 +13,13 @@ list.tweak-categories separator {
 .nautilus-window {
   // keep details box visible
   // details box looks ugly when many items are selected and it floats above the orange
+  background-image: none;
+  background-color: white;
+  &:backdrop { background-color: _backdrop_color(white); }
+
   *scrolledwindow:backdrop { opacity: 0.9; } // what is this for?
-   // Makes icons less bright in backdrop
+
+  // Makes icons less bright in backdrop
   paned box.floating-bar {
     background: $bg_color;
     border: 1px solid $borders_color;
@@ -25,6 +30,16 @@ list.tweak-categories separator {
     // applies to the desktop too
     background: transparent;
     border-color: transparent;
+  }
+
+  treeview.view,
+  treeview.view header button {
+    background-color: white;
+    background-image: none;
+    border-color: transparentize($borders_color, 0.6);
+    border-left: 1px;
+
+    &:backdrop {background-color: _backdrop_color(white);}
   }
 
   scrolledwindow widget.view:selected {
@@ -42,14 +57,32 @@ list.tweak-categories separator {
     &.dnd { border-style: none; }
   }
 
-  notebook > header > tabs > tab {
-    margin-right: 9px;
+  notebook > header > tabs {
+    background: $porcelain;
+    &:backdrop { background-color: $backdrop_bg_color; }
+
+
+    & > tab {
+      border-bottom: 1px solid transparentize($borders_color, 0.6);
+      margin: 0px;
+
+      &:checked {
+        border-color: transparentize($borders_color, 0.6);
+        border-bottom: none;
+
+        &:backdrop { background-color: _backdrop_color(white); }
+      }
+
+      &:not(:checked) {
+        & label { color: transparentize($text_color, 0.5); }
+      }
+    }
   }
 
-  paned > separator{
+  paned > separator {
     // separator between sidebar and main window view
     &, &:backdrop {
-      background-image: image($borders_color);
+      background-image: image(rgba(0, 0, 0, 0.06));
     }
   }
 }
@@ -57,10 +90,8 @@ list.tweak-categories separator {
 
 .nautilus-desktop-window {
   .nautilus-desktop.view {
-    // use white text for desktop icons
-    // otherwise it uses the variant dependent grey or white text color
     color: $selected_fg_color;
-    text-shadow: 0px 1px 2px rgba(0, 0, 0, 0.6);
+    text-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
   }
 }
 
@@ -399,5 +430,5 @@ window.background.chromium {
 /*********************
  * GNOME Photos *
  *********************/
-//removes the black background for picture tiles 
+//removes the black background for picture tiles
 .documents-scrolledwin.frame.frame widget flowboxchild.tile { background-color: transparent; }

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -32,7 +32,6 @@ list.tweak-categories separator {
     border-color: transparent;
   }
 
-  treeview.view,
   treeview.view header button {
     background-color: white;
     background-image: none;
@@ -40,9 +39,6 @@ list.tweak-categories separator {
     border-left: 1px;
 
     &:backdrop {background-color: _backdrop_color(white);}
-  }
-
-  treeview.view header button {
     &:hover {background-color: $bg_color;}
   }
 

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -38,8 +38,8 @@ list.tweak-categories separator {
     border-color: transparentize($borders_color, 0.6);
     border-left: 1px;
 
-    &:backdrop {background-color: _backdrop_color(white);}
     &:hover {background-color: $bg_color;}
+    &:backdrop { background-color: #EEEFF0; } // It should be _backdrop_color(white); but that does not work.
   }
 
   scrolledwindow widget.view:selected {
@@ -60,8 +60,6 @@ list.tweak-categories separator {
   notebook > header > tabs {
     background: $porcelain;
     &:backdrop { background-color: $backdrop_bg_color; }
-    border: 1px solid transparentize($borders_color, 0.6);
-
 
     & > tab {
       border-bottom: 1px solid transparentize($borders_color, 0.6);
@@ -71,7 +69,7 @@ list.tweak-categories separator {
         border-color: transparentize($borders_color, 0.6);
         border-bottom: none;
 
-        &:backdrop { background-color: _backdrop_color(white); }
+        &:backdrop { background-color: #EEEFF0; }  // It should be _backdrop_color(white); but that does not work.
       }
 
       &:not(:checked) {

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -42,6 +42,10 @@ list.tweak-categories separator {
     &:backdrop {background-color: _backdrop_color(white);}
   }
 
+  treeview.view header button {
+    &:hover {background-color: $bg_color;}
+  }
+
   scrolledwindow widget.view:selected {
     // reduces orangeness of selected folder icons
     background-color: rgba(255, 255, 255, 0.1); // folder icon is tinted based on this
@@ -60,6 +64,7 @@ list.tweak-categories separator {
   notebook > header > tabs {
     background: $porcelain;
     &:backdrop { background-color: $backdrop_bg_color; }
+    border: 1px solid transparentize($borders_color, 0.6);
 
 
     & > tab {

--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -5,7 +5,7 @@
 
 $light: if($variant=='light', true, false);
 $base_color: if($variant == 'light', #FFFFFF, $inkstone);
-$bg_color: if($variant == 'light', #FAFAFA, darken($inkstone,1%));
+$bg_color: if($variant == 'light', #F5F6F7, darken($inkstone,1%));
 $fg_color: if($variant == 'light', $inkstone, $porcelain);
 $text_color: if($variant == 'light', #2D2D2D, $porcelain);
 //
@@ -26,7 +26,7 @@ $scrollbar_slider_color: transparentize($fg_color, 0.4);
 $scrollbar_slider_hover_color: $fg_color;
 $scrollbar_slider_active_color: if($variant=='light', darken($selected_bg_color, 10%), lighten($selected_bg_color, 10%));
 //
-$button_bg_color: if($variant == 'light', darken($bg_color, 3%), lighten($bg_color, 7%));
+$button_bg_color: if($variant == 'light', lighten($bg_color, 3%), lighten($bg_color, 7%));
 //
 $warning_color: $yellow;
 $error_color: $red;
@@ -44,8 +44,8 @@ $osd_text_color: transparentize($osd_fg_color, .1);
 $osd_insensitive_bg_color: transparentize(mix($osd_fg_color, opacify($osd_bg_color, 1), 10%), 0.5);
 $osd_insensitive_fg_color: mix($osd_fg_color, opacify($osd_bg_color, 1), 50%);
 //
-$sidebar_bg_color: if($variant == 'light', darken($bg_color, 5%), lighten($bg_color, 5%));
-$sidebar_bg_color: adjust-color($sidebar_bg_color, $red: 2); // add +2 on red channel to make the color warmer like headerbar
+$sidebar_bg_color: if($variant == 'light', white, lighten($bg_color, 5%));
+//$sidebar_bg_color: adjust-color($sidebar_bg_color, $red: 2); // add +2 on red channel to make the color warmer like headerbar
 $base_hover_color: transparentize($fg_color, 0.85);
 $base_active_color: transparentize($fg_color, 0.80);
 //

--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -45,7 +45,6 @@ $osd_insensitive_bg_color: transparentize(mix($osd_fg_color, opacify($osd_bg_col
 $osd_insensitive_fg_color: mix($osd_fg_color, opacify($osd_bg_color, 1), 50%);
 //
 $sidebar_bg_color: if($variant == 'light', white, lighten($bg_color, 5%));
-//$sidebar_bg_color: adjust-color($sidebar_bg_color, $red: 2); // add +2 on red channel to make the color warmer like headerbar
 $base_hover_color: transparentize($fg_color, 0.85);
 $base_active_color: transparentize($fg_color, 0.80);
 //

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2718,7 +2718,7 @@ scrollbar {
     &.dragging,
     &.hovering {
       border-style: none;
-      background-color: $scrollbar_bg_color;
+      background-color: transparent; //$scrollbar_bg_color;
       border-radius: $small_radius;
 
       &:backdrop { background-color: transparentize($backdrop_scrollbar_bg_color, 0.2); }
@@ -3755,25 +3755,12 @@ scrolledwindow {
   }
 }
 
-// Avoid Gnome-Control-Center's language list to use sidebar colors
-frame > scrolledwindow > viewport > list {
-    background-color: /*white*/ $bg_color;
-    &:backdrop { background-color: $backdrop_bg_color; }
-
-}
-
 //vbox and hbox separators
 separator {
-  background: transparentize(/*black*/$borders_color, 0.9);
+  background: transparentize($borders_color, 0.85);
   min-width: 1px;
   min-height: 1px;
 }
-
-// box > separator.vertical {
-  // target separators between sidebars and views -> this may need to be a thing
-  // background: $borders_color;
-// }
-
 
 /*********
  * Lists *
@@ -4065,7 +4052,12 @@ row image.sidebar-icon { opacity: $_placesidebar_icons_opacity; } // dim the sid
                                                                   // on this oddity
 
 placessidebar {
-  > viewport.frame { border-style: none; }
+  > viewport.frame {
+    background-color: $bg_color;
+    border-style: none;
+
+    &:backdrop { background-color: $backdrop_bg_color; };
+  }
 
   > viewport > list { margin-top: -3px; }
 

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2160,9 +2160,9 @@ treeview.view {
   padding: 0 6px;
   background-image: none;
   border-style: none solid solid none;
-  &:not(:hover), &:not(:active) { background-image: image($bg_color); }
+  &:not(:hover), &:not(:active) { background-image: if($variant==light, image(white), image($bg_color)); }
   &:backdrop { background-image: image($backdrop_bg_color); }
-  &:hover, &:active { background-image: none; }
+  &:hover, &:active { background-image: image($bg_color); }
   border-color: $borders_color; // don't darken the bottom border color
   border-radius: 0;
 
@@ -3940,7 +3940,7 @@ messagedialog { // Message Dialog styling
 }
 
 filechooser {
-  background-color: white;
+  background-color: if($variant==light, white, $bg_color);
 
   .dialog-action-box {
     border-top: 1px solid $borders_color;
@@ -3949,26 +3949,30 @@ filechooser {
   }
 
   #pathbarbox {
-    $_bg: $sidebar_bg_color;
+    $_bg: $bg_color;
 
     background: $_bg;
     border-bottom: 1px solid $borders_color;
-    &:backdrop{background:  $backdrop_sidebar_bg_color;}
+    &:backdrop{background: darken($backdrop_bg_color, 5%);}
 
     .path-bar.linked button {
-      background: darken($_bg, 5%);
+      background: if($variant==light, darken($_bg, 10%), darken($_bg, 5%));
       &:backdrop { background: $_bg}
       &, & label { color: $text_color }
 
       &:backdrop label { color: $backdrop_text_color; }
       &:checked label { font-weight: 500; }
+      &:backdrop{background: darken($backdrop_bg_color, 5%);}
     }
   }
 
-  & actionbar { background-color: $sidebar_bg_color; }
+  & actionbar {
+    background-color: $bg_color;
+    &:backdrop{background: darken($backdrop_bg_color, 5%);}
+  }
+  // picture preview pane
   & placessidebar ~ box box > stack ~ box  {
-    // what is this for?
-    background-color: #efeded; // fixed color won't work with dark theme
+    background-color: $bg_color; // fixed color won't work with dark theme
     border: 1px solid rgba(0, 0, 0, 0.2);
     border-width: 0 1px;
     padding: 10px;
@@ -4056,7 +4060,7 @@ placessidebar {
     background-color: $bg_color;
     border-style: none;
 
-    &:backdrop { background-color: $backdrop_bg_color; };
+    &:backdrop { background-color: darken($backdrop_bg_color, 5%); };
   }
 
   > viewport > list { margin-top: -3px; }

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4060,7 +4060,7 @@ placessidebar {
     background-color: $bg_color;
     border-style: none;
 
-    &:backdrop { background-color: darken($backdrop_bg_color, 5%); };
+    &:backdrop { background-color: $backdrop_bg_color; };
   }
 
   > viewport > list { margin-top: -3px; }

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -226,12 +226,8 @@
     @if $flat {
       border-color: $c;
       box-shadow: none;
-    }
-
-    @else {
+    } @else {
       border-color: $_border;
-      border-bottom-color: darken($_border, if($c == $headerbar_bg_color or $c == $button_bg_color, 20%, 12%));
-      box-shadow: 0 1px transparentize(black, 0.9);
     }
   }
 
@@ -246,11 +242,9 @@
     @if $flat {
       border-color: $_bg;
       box-shadow: none;
-    }
-
-    @else {
+    } @else {
       border-color: $_border;
-      border-bottom-color: darken($_border, if($c == $headerbar_bg_color or $c == $button_bg_color, 20%, 12%));
+      border-bottom-color: darken($_border, if($c == $headerbar_bg_color or $c == $button_bg_color, 15%, 12%));
       box-shadow: 0 1px transparentize(black, 0.9);
     }
   }


### PR DESCRIPTION
Initially discussed in #407 and revived by [this comment](https://github.com/ubuntu/gtk-communitheme/pull/407#issuecomment-395594228)

But basically is because current mainview and sidebar and button (yes I know) look a bit dull.

---

**EDIT** still to be done: 
- [x] filechooser
- [x] treeview header button hover 
- [x] bug when right clicking a row in treeview 
- [x] fix sidebar backdrop



Here are a new attempt. Please make a long test, several pieces can be affected (One for all, the filechooser, that is to be fixed already).

![image](https://user-images.githubusercontent.com/2883614/41181724-19d1d3dc-6b73-11e8-82ab-e0bd946c645a.png)
![image](https://user-images.githubusercontent.com/2883614/41181744-2677a9a4-6b73-11e8-935b-7cfc6500b03c.png)
![image](https://user-images.githubusercontent.com/2883614/41181771-42c9e9e6-6b73-11e8-8d9d-164fb86e91e5.png)
![image](https://user-images.githubusercontent.com/2883614/41181781-4b0cee1e-6b73-11e8-9fab-d3f04502193c.png)

Filechooser fixed
![image](https://user-images.githubusercontent.com/2883614/41191213-60f323c8-6bec-11e8-892a-b62d2395d088.png)
