### PR TITLE
Add a border left/right to GNOME Software's installed apps rows

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -234,6 +234,13 @@ terminal-window {
   > grid { margin-top: -24px; }
 }
 
+.list-box-app-row {
+  border-radius: 0px;
+  border-left: 1px solid $borders_color;
+  border-right: 1px solid $borders_color;
+  margin: -1px 0;
+}
+
 /***********
  * Gedit *
  ***********/


### PR DESCRIPTION
https://github.com/ubuntu/gtk-communitheme/issues/465

Before: https://user-images.githubusercontent.com/3986894/40322689-7aa7016c-5d33-11e8-8764-2de8eec1e585.png
After: https://user-images.githubusercontent.com/15329494/41205770-12cac1ce-6cfa-11e8-8ffa-d9eb64353e77.png


I'll leave the selection menu to @clobrano the button master :+1: 