### PR TITLE
Darktheme color changes

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -403,17 +403,17 @@ headerbar button image ~ window decoration ~ menu separator {
 
 .org-gnome-Todo {
   taskrow.activatable.new-task-row button.popup.toggle {
-   border-radius: 0px;
+   border-radius: 0px $small_radius $small_radius 0px ;
    border: none;
    border-left: 1px solid $borders-color;
    padding-left: 10px; padding-right: 10px;
-   -gtk-outline-radius: 0;
+   -gtk-outline-radius: 0px $small_radius $small_radius 0px;
 
   }
 
   viewport.view, listbox.transparent {
-   background-color: $sidebar_bg_color;
-   &:backdrop { background-color: $backdrop_sidebar_bg_color;}
+   background-color: darken($base_color,10%);
+   &:backdrop { background-color: darken($backdrop_base_color,10%)}
   }
 }
 

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -412,8 +412,8 @@ headerbar button image ~ window decoration ~ menu separator {
   }
 
   viewport.view, listbox.transparent {
-   background-color: darken($base_color,10%);
-   &:backdrop { background-color: darken($backdrop_base_color,10%)}
+   background-color: darken($base_color,5%);
+   &:backdrop { background-color: $backdrop_base_color}
   }
 }
 

--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -5,13 +5,13 @@
 
 $light: if($variant=='light', true, false);
 $base_color: if($variant == 'light', #FFFFFF, $inkstone);
-$bg_color: if($variant == 'light', #F5F6F7, darken($inkstone,5%));
+$bg_color: if($variant == 'light', #F5F6F7, darken($inkstone,3%));
 $fg_color: if($variant == 'light', $inkstone, $porcelain);
 $text_color: if($variant == 'light', #2D2D2D, $porcelain);
 //
 $selected_fg_color: white;
 $selected_bg_color: $orange;
-$borders_color: if($variant == 'light', darken($bg_color, 18%), darken($bg_color, 7%));
+$borders_color: if($variant == 'light', darken($bg_color, 18%), darken($bg_color, 8%));
 $link_color: $blue;
 $link_visited_color: if($variant == 'light', darken($link_color, 20%), lighten($link_color, 10%));
 $borders_edge: rgba(0, 0, 0, 0.1);
@@ -26,7 +26,7 @@ $scrollbar_slider_color: transparentize($fg_color, 0.4);
 $scrollbar_slider_hover_color: $fg_color;
 $scrollbar_slider_active_color: if($variant=='light', darken($selected_bg_color, 10%), lighten($selected_bg_color, 10%));
 //
-$button_bg_color: if($variant == 'light', lighten($bg_color, 3%), lighten($bg_color, 7%));
+$button_bg_color: if($variant == 'light', lighten($bg_color, 3%), lighten($bg_color, 5%));
 //
 $warning_color: $yellow;
 $error_color: $red;
@@ -44,7 +44,7 @@ $osd_text_color: transparentize($osd_fg_color, .1);
 $osd_insensitive_bg_color: transparentize(mix($osd_fg_color, opacify($osd_bg_color, 1), 10%), 0.5);
 $osd_insensitive_fg_color: mix($osd_fg_color, opacify($osd_bg_color, 1), 50%);
 //
-$sidebar_bg_color: if($variant == 'light', white, lighten($bg_color, 5%));
+$sidebar_bg_color: if($variant == 'light', white, $base_color);
 $base_hover_color: transparentize($fg_color, 0.85);
 $base_active_color: transparentize($fg_color, 0.80);
 //

--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -14,9 +14,9 @@ $selected_bg_color: $orange;
 $borders_color: if($variant == 'light', darken($bg_color, 18%), darken($bg_color, 7%));
 $link_color: $blue;
 $link_visited_color: if($variant == 'light', darken($link_color, 20%), lighten($link_color, 10%));
-$borders_edge: rgba(0, 0, 0, 0.1);
+$borders_edge: if($variant == 'light',rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.4));
 $top_hilight: $borders_edge;
-$dark_fill: #CDCDCD;
+$dark_fill: if($variant == 'light',#CDCDCD, $ash);
 $menu_color: if($variant == 'light', $base_color, mix($bg_color, $base_color, 20%));
 $popover_bg_color: $bg_color;
 $popover_hover_color: if($variant=='light', darken($bg_color, 7%), lighten($bg_color, 7%));
@@ -26,7 +26,7 @@ $scrollbar_slider_color: transparentize($fg_color, 0.4);
 $scrollbar_slider_hover_color: $fg_color;
 $scrollbar_slider_active_color: if($variant=='light', darken($selected_bg_color, 10%), lighten($selected_bg_color, 10%));
 //
-$button_bg_color: if($variant == 'light', lighten($bg_color, 3%), lighten($bg_color, 5%));
+$button_bg_color: if($variant == 'light', lighten($bg_color, 3%), lighten($bg_color, 6%));
 //
 $warning_color: $yellow;
 $error_color: $red;

--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -5,7 +5,7 @@
 
 $light: if($variant=='light', true, false);
 $base_color: if($variant == 'light', #FFFFFF, $inkstone);
-$bg_color: if($variant == 'light', #F5F6F7, darken($inkstone,1%));
+$bg_color: if($variant == 'light', #F5F6F7, darken($inkstone,5%));
 $fg_color: if($variant == 'light', $inkstone, $porcelain);
 $text_color: if($variant == 'light', #2D2D2D, $porcelain);
 //

--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -63,7 +63,7 @@ $backdrop_base_color: if($variant == 'light', darken($base_color, 5%), $base_col
 $backdrop_text_color: transparentize($text_color, 0.2);
 $backdrop_bg_color: if($variant == 'light', darken($bg_color, 3%), lighten($bg_color, 2%));
 $backdrop_fg_color: mix($fg_color, $backdrop_bg_color, 50%);
-$backdrop_insensitive_color: if($variant == 'light', darken($backdrop_bg_color, 15%), $backdrop_bg_color);
+$backdrop_insensitive_color: if($variant == 'light', darken($backdrop_bg_color, 15%), lighten($backdrop_bg_color,15%));
 $backdrop_insensitive_dark_fill: $insensitive_dark_fill;
 $backdrop_selected_fg_color: if($variant == 'light', $backdrop_base_color, $backdrop_text_color);
 $backdrop_borders_color: if($variant == 'light',darken($borders_color, 3%), lighten($borders_color, 3%));

--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -17,7 +17,7 @@ $link_visited_color: if($variant == 'light', darken($link_color, 20%), lighten($
 $borders_edge: if($variant == 'light',rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.4));
 $top_hilight: $borders_edge;
 $dark_fill: if($variant == 'light',#CDCDCD, $ash);
-$menu_color: if($variant == 'light', $base_color, darken($base_color,3%));
+$menu_color: if($variant == 'light', $base_color, darken($base_color,5%));
 $popover_bg_color: $bg_color;
 $popover_hover_color: if($variant=='light', darken($bg_color, 7%), lighten($bg_color, 7%));
 //

--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -17,7 +17,7 @@ $link_visited_color: if($variant == 'light', darken($link_color, 20%), lighten($
 $borders_edge: if($variant == 'light',rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.4));
 $top_hilight: $borders_edge;
 $dark_fill: if($variant == 'light',#CDCDCD, $ash);
-$menu_color: if($variant == 'light', $base_color, mix($bg_color, $base_color, 20%));
+$menu_color: if($variant == 'light', $base_color, darken($base_color,3%));
 $popover_bg_color: $bg_color;
 $popover_hover_color: if($variant=='light', darken($bg_color, 7%), lighten($bg_color, 7%));
 //

--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -11,7 +11,7 @@ $text_color: if($variant == 'light', #2D2D2D, $porcelain);
 //
 $selected_fg_color: white;
 $selected_bg_color: $orange;
-$borders_color: if($variant == 'light', darken($bg_color, 18%), darken($bg_color, 8%));
+$borders_color: if($variant == 'light', darken($bg_color, 18%), darken($bg_color, 7%));
 $link_color: $blue;
 $link_visited_color: if($variant == 'light', darken($link_color, 20%), lighten($link_color, 10%));
 $borders_edge: rgba(0, 0, 0, 0.1);
@@ -59,16 +59,16 @@ $insensitive_dark_fill: mix($bg_color, $dark_fill);
 $insensitive_borders_color: transparentize($borders_color, 0.4);
 
 //colors for the backdrop state, derived from the main colors.
-$backdrop_base_color: if($variant == 'light', darken($base_color, 5%), lighten($base_color, 5%));
+$backdrop_base_color: if($variant == 'light', darken($base_color, 5%), $base_color);
 $backdrop_text_color: transparentize($text_color, 0.2);
-$backdrop_bg_color: if($variant == 'light', darken($bg_color, 3%), lighten($bg_color, 1%));
+$backdrop_bg_color: if($variant == 'light', darken($bg_color, 3%), lighten($bg_color, 2%));
 $backdrop_fg_color: mix($fg_color, $backdrop_bg_color, 50%);
-$backdrop_insensitive_color: if($variant == 'light', darken($backdrop_bg_color, 15%), lighten($backdrop_bg_color, 15%));
+$backdrop_insensitive_color: if($variant == 'light', darken($backdrop_bg_color, 15%), $backdrop_bg_color);
 $backdrop_insensitive_dark_fill: $insensitive_dark_fill;
 $backdrop_selected_fg_color: if($variant == 'light', $backdrop_base_color, $backdrop_text_color);
 $backdrop_borders_color: if($variant == 'light',darken($borders_color, 3%), lighten($borders_color, 3%));
-$backdrop_dark_fill: if($variant == 'light', darken($dark_fill, 5%), lighten($dark_fill, 5%));
-$backdrop_sidebar_bg_color: if($variant == 'light',darken($sidebar_bg_color, 3%), lighten($sidebar_bg_color, 1%));
+$backdrop_dark_fill: if($variant == 'light', darken($dark_fill, 5%), $dark_fill);
+$backdrop_sidebar_bg_color: if($variant == 'light',darken($sidebar_bg_color, 3%), $sidebar_bg_color);
 
 $backdrop_scrollbar_bg_color: darken($backdrop_bg_color, 3%);
 $backdrop_scrollbar_slider_color: transparentize($backdrop_fg_color, 0.4);

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -3922,7 +3922,7 @@ filechooser {
 
     background: $_bg;
     border-bottom: 1px solid $borders_color;
-    &:backdrop{background: darken($backdrop_bg_color, 5%);}
+    &:backdrop{background: if($variant==light,darken($backdrop_bg_color, 5%), $backdrop_bg_color);}
 
     .path-bar.linked button {
       background: if($variant==light, darken($_bg, 10%), darken($_bg, 5%));

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4467,7 +4467,7 @@ decoration {
 
   // this needs to be transparent
   // see bug #722563
-  $_wm_border: transparentize(black, 0.77);
+  $_wm_border: if($variant == 'light',transparentize(black, 0.77), darken($bg_color, 7%));
 
   box-shadow: $window_decoration_shadow;
 

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2887,7 +2887,7 @@ radio {
   & {
     // for unchecked
     border: 1px solid;
-    $_c: if($light, white, $bg_color);
+    $_c: if($light, white, transparent);
 
     @each $state, $t in ("", "normal"), (":hover", "hover"),
                         (":active", "active"), (":disabled", "insensitive"),

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4467,7 +4467,7 @@ decoration {
 
   // this needs to be transparent
   // see bug #722563
-  $_wm_border: if($variant == 'light',transparentize(black, 0.77), darken($bg_color, 7%));
+  $_wm_border: if($variant == 'light',transparentize(black, 0.77), darken($bg_color, 9%));
 
   box-shadow: $window_decoration_shadow;
 

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4467,7 +4467,7 @@ decoration {
 
   // this needs to be transparent
   // see bug #722563
-  $_wm_border: if($variant == 'light',transparentize(black, 0.77), darken($bg_color, 9%));
+  $_wm_border: if($variant == 'light',transparentize(black, 0.77),transparentize(black, 0.5));
 
   box-shadow: $window_decoration_shadow;
 

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -377,7 +377,7 @@
     @if $c == $headerbar_bg_color {
       $_bg: $backdrop_headerbar_bg_color;
     } @else {
-      $_bg: _backdrop_color($c); //if($c==$button_bg_color, $backdrop_bg_color, _backdrop_color($c));
+      $_bg: _backdrop_color($c);
     }
 
     -gtk-icon-effect: dim;
@@ -403,10 +403,17 @@
       $_bg: darken($c, 7%);
     }
 
+    $_border_top_color: null;
+    @if $c==$headerbar_bg_color { $_border_top_color: darken($_border,10%);}
+    @else if $c==$button_bg_color {
+      @if $variant=='light' { $_border_top_color: darken($_border,10%);}
+      @else { $_border_top_color: darken($_border,2%);}
+    }
+
     //box-shadow: none;
     background-color: $_bg;
     border-color: if($flat==true, $_bg, $_bc);
-    border-top-color: if($flat==true, $_bg, darken($_border, if($c == $headerbar_bg_color or $c == $button_bg_color, 10%, 6%)));
+    border-top-color: $_border_top_color;//if($flat==true, $_bg, darken($_border, if($c == $headerbar_bg_color or $c == $button_bg_color, 10%, 6%)));
     box-shadow: none;
 
     label, & { color: if($tc != $fg_color, mix($tc, $_bg, 80%), $backdrop_fg_color); }
@@ -457,7 +464,13 @@
     //box-shadow: none;
     background-color: $_bg;
     border-color: if($flat==true, $_bg, $_bc);
-    border-top-color: darken($_border, if($c == $headerbar_bg_color or $c == $button_bg_color, 15%, 9%));
+    $_border_top_color: null;
+    @if $c==$headerbar_bg_color { $_border_top_color: darken($_border,15%);}
+    @else if $c==$button_bg_color {
+      @if $variant=='light' { $_border_top_color: darken($_border,15%);}
+      @else { $_border_top_color: darken($_border,1%);}
+    }
+    border-top-color: $_border_top_color;
 
     label { color: if($c != $button_bg_color, mix($tc, $_bg, 35%), transparentize($backdrop_text_color, 0.5)); }
   }

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -313,7 +313,7 @@
         $_bg: $bg_color;
     } @else if $c == $headerbar_bg_color {
         $_bg: $c;
-    } @else if $c == $red, $green, $yellow, $blue, $purple {
+    } @else if $c == $red or $green or $yellow or $blue or $purple {
         $_bg: transparentize($c, .1);
     }
       @else {
@@ -427,7 +427,7 @@
         text-shadow: none;
         -gtk-icon-shadow: none;
     }
-    @else if $c == $red, $green, $yellow, $blue, $purple {
+    @else if $c == $red or $green or $yellow or $blue or $purple {
         $_bg: transparentize($c, .1);
     }
     @else {

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -212,6 +212,9 @@
   // backdrop, backdrop-active, backdrop-insensitive, backdrop-insensitive-active,
   // osd, osd-hover, osd-active, osd-insensitive, osd-backdrop, undecorated
 
+  $_c_flat_headerbar: darken($headerbar_bg_color, 10%);
+  $_c_flat_headerbar_active: darken($headerbar_bg_color, 5%);
+
   $_pressed: if(lightness($c)<15%, transparentize(black, 0.4), transparentize(black, 0.8));
   $shadow: null;
   @if $variant == "dark" or $c != $button_bg_color { $shadow: 0px 2px 2px -1px $borders_edge, inset 0 -1px _button_hilight_color($c); }
@@ -235,10 +238,10 @@
   @else if $t==hover {
     // hovered button
     -gtk-icon-effect: highlight;
-    @if $flat == true { $c: darken($c, 10%); }
+    @if $flat == true { $c: $_c_flat_headerbar; }
     $_bg: if(lightness($c)<35%, lighten($c, 25%), lighten($c, 5%));
     background-color: $_bg;
-    @if $variant=='dark' and $c != darken($headerbar_bg_color, 10%) { background-color: lighten($c,1%); }
+    @if $variant=='dark' and $c != $_c_flat_headerbar { background-color: lighten($c,1%); }
     color: $tc;
 
     @if $flat {
@@ -253,11 +256,11 @@
 
   @else if $t==active {
     @if $c == $headerbar_bg_color { $_border: darken($c, 3%); }
-    @if $flat == true { $c: darken($c, 5%); }
+    @if $flat == true { $c: $_c_flat_headerbar_active; }
     $_bg: if(lightness($c)<35%, lighten($c, 18%), darken($c, 7%));
 
     background-color: $_bg;
-    @if $variant=='dark' and $c != darken($headerbar_bg_color,5%) { background-color: darken($button_bg_color,6.5%); }
+    @if $variant=='dark' and $c != $_c_flat_headerbar_active { background-color: darken($button_bg_color,6.5%); }
     box-shadow: inset 0 1px 1px 0px rgba(0, 0, 0, if($c==$headerbar_bg_color, .15, 0.05));
     border-color: $_border;
     border-top-color: darken($_border, if($c == $headerbar_bg_color or $c == $button_bg_color, 20%, 12%));

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -401,7 +401,7 @@
       $_bg: darken($c, 12%);
     }
     @else if $c!=$headerbar_bg_color and $variant=='dark'{
-      $_bg: darken($c, 1%);
+      $_bg: darken($c, 7%);
     }
 
     //box-shadow: none;

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -370,8 +370,11 @@
 
     @if $c==$headerbar_bg_color {
       $_bg: mix($c, $headerbar_bg_color, 85%);
-    } @else {
+    } @else if $c!=$headerbar_bg_color and $variant=='light'{
       $_bg: darken($c, 12%);
+    }
+    @else if $c!=$headerbar_bg_color and $variant=='dark'{
+      $_bg: darken($c, 1%);
     }
 
     //box-shadow: none;

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -362,8 +362,8 @@
       border-color: $_bg;
       box-shadow: none;
     } @else {
-      border-color: _border_color($_bg, $darker: true);
-      border-top-color: darken($_border, if($c == $headerbar_bg_color or $c == $button_bg_color, 15%, 9%));
+      border-color: $insensitive_borders_color;
+      border-top-color: darken($insensitive_borders_color, 10%);
       box-shadow: inset 0 1px 1px 0px rgba(0, 0, 0, if($c==$headerbar_bg_color, .15, 0.05));
     }
 

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -4,12 +4,11 @@
 
 @function _backdrop_color($c) {
   // adjusts colors for use in the backdrop state
-  // colors are lightened for both light and dark, the level may be changed later
-  @if $variant != 'light' {
+  @if $variant == 'light' {
     @return lighten($c, 5%);
   }
   @else {
-    @return lighten($c, 5%);
+    @return darken($c, 2%);
   }
 }
 

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -238,7 +238,7 @@
     @if $flat == true { $c: darken($c, 10%); }
     $_bg: if(lightness($c)<35%, lighten($c, 25%), lighten($c, 5%));
     background-color: $_bg;
-    @if $variant=='dark' and $c != darken($headerbar_bg_color, 10%) { background-color: $base_hover_color;}
+    @if $variant=='dark' and $c != darken($headerbar_bg_color, 10%) { background-color: lighten($c,1%); }
     color: $tc;
 
     @if $flat {
@@ -257,6 +257,7 @@
     $_bg: if(lightness($c)<35%, lighten($c, 18%), darken($c, 7%));
 
     background-color: $_bg;
+    @if $variant=='dark' and $c != darken($headerbar_bg_color,5%) { background-color: darken($button_bg_color,6.5%); }
     box-shadow: inset 0 1px 1px 0px rgba(0, 0, 0, if($c==$headerbar_bg_color, .15, 0.05));
     border-color: $_border;
     border-top-color: darken($_border, if($c == $headerbar_bg_color or $c == $button_bg_color, 20%, 12%));
@@ -275,6 +276,7 @@
     }
 
     background-color: $_bg;
+    @if $variant=='dark' and $c != $headerbar_bg_color { background-color: darken($button_bg_color,7%); }
   }
 
   @else if $t==insensitive {

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -212,9 +212,6 @@
   // backdrop, backdrop-active, backdrop-insensitive, backdrop-insensitive-active,
   // osd, osd-hover, osd-active, osd-insensitive, osd-backdrop, undecorated
 
-  $_c_flat_headerbar: darken($headerbar_bg_color, 10%);
-  $_c_flat_headerbar_active: darken($headerbar_bg_color, 5%);
-
   $_pressed: if(lightness($c)<15%, transparentize(black, 0.4), transparentize(black, 0.8));
   $shadow: null;
   @if $variant == "dark" or $c != $button_bg_color { $shadow: 0px 2px 2px -1px $borders_edge, inset 0 -1px _button_hilight_color($c); }
@@ -238,10 +235,17 @@
   @else if $t==hover {
     // hovered button
     -gtk-icon-effect: highlight;
-    @if $flat == true { $c: $_c_flat_headerbar; }
-    $_bg: if(lightness($c)<35%, lighten($c, 25%), lighten($c, 5%));
+
+    $_bg: null;
+
+    @if $c==$headerbar_bg_color { $_bg: lighten($c, 15%); }
+    @else if $c==$success_color or $destructive_color or $neutral_color or $purple { $_bg: lighten($c, 5%); }
+    @else if $c==$button_bg_color {
+      @if $variant=='light' { $_bg: lighten($c, 25%); }
+      @else { $_bg: lighten($c, 1%); }
+    }
+
     background-color: $_bg;
-    @if $variant=='dark' and $c != $_c_flat_headerbar { background-color: lighten($c,1%); }
     color: $tc;
 
     @if $flat {
@@ -255,16 +259,36 @@
   }
 
   @else if $t==active {
-    @if $c == $headerbar_bg_color { $_border: darken($c, 3%); }
-    @if $flat == true { $c: $_c_flat_headerbar_active; }
-    $_bg: if(lightness($c)<35%, lighten($c, 18%), darken($c, 7%));
+    $_bg: null;
+    $_border_top_color: null;
 
-    background-color: $_bg;
-    @if $variant=='dark' and $c != $_c_flat_headerbar_active { background-color: darken($button_bg_color,6.5%); }
+    @if $c==$headerbar_bg_color {
+      $_bg: lighten($c, 13%);
+      $_border: darken($c, 3%);
+      $_border_top_color: darken($_border, 20%);
+    }
+    @else if $c==$button_bg_color{
+      @if $variant=='light' {
+        $_bg: darken($c, 7%);
+        $_border: $borders_color;
+        $_border_top_color: darken($_border, 25%);
+      }
+      @else {
+        $_bg: darken($button_bg_color,10%);
+        $_border: $borders_color;
+        $_border_top_color: darken($_border, 8%);
+      }
+    }
+    @else if $c==$success_color or $destructive_color or $neutral_color or $purple {
+      $_bg: darken($c, 10%);
+      $_border: darken($c, 15%);
+      $_border_top_color: darken($_border, 5%);
+    }
+
     box-shadow: inset 0 1px 1px 0px rgba(0, 0, 0, if($c==$headerbar_bg_color, .15, 0.05));
     border-color: $_border;
-    border-top-color: darken($_border, if($c == $headerbar_bg_color or $c == $button_bg_color, 20%, 12%));
-    color: $tc;
+    border-top-color: $_border_top_color;
+    background-color: $_bg;
   }
 
   @else if $t==active-hover {

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -267,7 +267,7 @@
     $_border_top_color: null;
 
     @if $c==$headerbar_bg_color {
-      $_bg: lighten($c, 13%);
+      $_bg: lighten($c, 10%);
       $_border: darken($c, 3%);
       $_border_top_color: darken($_border, 20%);
     }

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -8,7 +8,12 @@
     @return lighten($c, 5%);
   }
   @else {
-    @return darken($c, 2%);
+    @if $c!=$orange {
+      @return darken($c, 2%);
+    }
+    @else {
+      @return lighten($c, 5%);
+    }
   }
 }
 

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -420,8 +420,12 @@
     $_bc: if($c != $button_bg_color, _backdrop_color(_border_color($c)), $backdrop_borders_color);
     @if $c == $headerbar_bg_color {
       $_bg: mix($c, $headerbar_bg_color, 85%);
-    } @else {
+    }
+    @else if $c!=$headerbar_bg_color and $variant=='light'{
       $_bg: darken($c, 15%);
+    }
+    @else if $c!=$headerbar_bg_color and $variant=='dark'{
+      $_bg: darken($c, 5%);
     }
 
     //box-shadow: none;

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -238,6 +238,7 @@
     @if $flat == true { $c: darken($c, 10%); }
     $_bg: if(lightness($c)<35%, lighten($c, 25%), lighten($c, 5%));
     background-color: $_bg;
+    @if $variant=='dark' and $c != darken($headerbar_bg_color, 10%) { background-color: $base_hover_color;}
     color: $tc;
 
     @if $flat {


### PR DESCRIPTION
The following changes were made only for the dark theme:
- bg color 
- button color 
- border color 
- button color 
- button active/hover/insensitive colors
- backdrop button active/hover/insensitive colors
- some gnome todo tweaks

@madsrh  please check out the look
@clobrano please double check the implementation. especially in _drawing

Despite the must have changes like super bright button hovers and pressed colors I changed the backdrop with the following idea in mind:
- don't change to much from the active colors
- only soften the border and text color


To do:

- [x]  Checkboxes/Radio btns background
- [x] Color of insensitive text in the backdrop