### PR TITLE
Button hover slighly darker

### DIFF
--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -235,8 +235,10 @@
   @else if $t==hover {
     // hovered button
     -gtk-icon-effect: highlight;
+
     @if $flat == true { $c: darken($c, 10%); }
-    $_bg: if(lightness($c)<35%, lighten($c, 25%), lighten($c, 5%));
+
+    $_bg: if(lightness($c)<35%, lighten($c, 25%), darken($c, 1%));
     background-color: $_bg;
     color: $tc;
 


### PR DESCRIPTION
This comes from #532, where buttons became so bright that no effect was visible on hover.

This PR add a slight darker color on hover. Note that it affects also suggested action buttons

![button-hover-darker](https://user-images.githubusercontent.com/2883614/41308386-03dc5898-6e7c-11e8-8d91-9fb2878dec22.gif)

