### PR TITLE
Made switch's selection ring more similar to the button's one

### DIFF
--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -631,7 +631,7 @@
     min-height: 16px;
     min-width: 16px;
     outline-color: $focus_color;
-    outline-offset: -1px;
+    outline-offset: -2px;
     transition: $button_transition;
     -gtk-outline-radius: $small_radius;
   }


### PR DESCRIPTION
Currently, switch's selection ring is placed in correspondence of
slider's border, while in button and similar widgets it is slightly
internal to the widget itself.

This commit changes the switch's outline-offset from -1px to -2px.

closes #491 