### PR TITLE
Improved stack-switcher button backdrop color

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1676,7 +1676,7 @@ headerbar {
       }
 
       &:backdrop {
-        background-color: mix($c, $headerbar_bg_color, 50%);
+        background-color: _backdrop_color($c);
         color: $backdrop_headerbar_insensitive_color;
 
         &:checked {
@@ -1694,7 +1694,7 @@ headerbar {
       border-color: $c;
       border-radius: $small_radius;
 
-      &:backdrop { border-color: mix($c, $headerbar_bg_color, 50%); }
+      &:backdrop { border-color: _backdrop_color($c); }
 
       button {
         // style the stackswitcher buttons


### PR DESCRIPTION
currently, stack-switcher button color in backdrop is darker than the
headerbar's one in the same state, while in normal state the color
relationship is inverted (hb darker then stack-switcher). This causes
a bad transition effect.

Using _backdrop_color function to automatically get a valid bg color
for this widget.

Before
![peek 2018-06-14 15-24](https://user-images.githubusercontent.com/2883614/41414685-0992256c-6fe7-11e8-97ee-9f1a9df3d48a.gif)

After
![peek 2018-06-14 15-19](https://user-images.githubusercontent.com/2883614/41414692-0e88b04a-6fe7-11e8-9c47-2d6fd15948e5.gif)
