### PR TITLE
Fix headerbar button height > width

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1853,8 +1853,8 @@ headerbar {
   spinbutton,
   // separator,
   button {
-    margin-top: 4px;
-    margin-bottom: 4px;
+    margin-top: 5px;
+    margin-bottom: 5px;
   }
   switch, separator {
     margin-top: 8px;


### PR DESCRIPTION
On headerbar image buttons are taller than wide, except appmenu button.

Fixing this adjusting headerbar top and bottom margins.
Incidentally, this also fixes issue #381 

![peek 2018-06-14 16-07](https://user-images.githubusercontent.com/2883614/41417389-80f58bfc-6fed-11e8-97f6-9a4bcbdbc3f0.gif)
