### PR TITLE
Added gray hover effect to circular slider

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -3130,7 +3130,9 @@ scale {
     transition: $button_transition;
     transition-property: background, border, box-shadow;
 
-    &:hover { border-color: mix($c, $borders_color); } // TODO: what should the focused slider look like?
+    &:hover {
+      background-color: darken(white, 5%);
+    }
 
     &:active { border-color: _border_color($c); }
 


### PR DESCRIPTION
This change gives to circular sliders the same hover effect that check and radio buttons have

Note: for non circular sliders, we need to create the appropriate png

see #397 