### PR TITLE
re-introducing backdrop hover effect

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -15,7 +15,7 @@ list.tweak-categories separator {
   // details box looks ugly when many items are selected and it floats above the orange
   background-image: none;
   background-color: if($variant==light,white,$base_color);
-  &:backdrop { background-color: if($variant==light,_backdrop_color(white),$backdrop_base_color); }
+  &:backdrop { background-color: $backdrop_base_color }
 
   *scrolledwindow:backdrop { opacity: 0.9; } // what is this for?
 

--- a/Communitheme/gtk-3.0/_colors.scss
+++ b/Communitheme/gtk-3.0/_colors.scss
@@ -27,6 +27,7 @@ $scrollbar_slider_hover_color: $fg_color;
 $scrollbar_slider_active_color: if($variant=='light', darken($selected_bg_color, 10%), lighten($selected_bg_color, 10%));
 //
 $button_bg_color: if($variant == 'light', lighten($bg_color, 3%), lighten($bg_color, 6%));
+$button_backdrop_bg_color: transparentize($button_bg_color, 0.3);
 //
 $warning_color: $yellow;
 $error_color: $red;

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -431,6 +431,7 @@ treeview, row {
     outline-offset: -2px;
     -gtk-outline-radius: $small_radius;
  }
+ &:backdrop:hover { background-color: lighten($base_hover_color, 20%); }
 }
 
 treeview entry {
@@ -3511,7 +3512,7 @@ progressbar {
       }
     }
 
-    // ...on selected list rows
+    // ...on selected nist rows
     row:selected & { &:disabled, & { border-color: $c; }} // TODO: what program uses this so it can be tested out?
 
     // OSD

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4577,7 +4577,7 @@ button.titlebutton {
 
   &:not(.close):not(.appmenu){
     &:hover {
-      @include draw_circle($c) ;
+      @include draw_circle($c);
     }
     &:active {
       @include draw_circle($c);

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2901,9 +2901,13 @@ radio {
     border: 1px solid;
     $_c: if($light, white, transparent);
 
-    @each $state, $t in ("", "normal"), (":hover", "hover"),
-                        (":active", "active"), (":disabled", "insensitive"),
-                        (":backdrop", "backdrop"), (":backdrop:disabled", 'backdrop-insensitive') {
+    @each $state, $t in ("", "normal"),
+                        (":hover", "hover"),
+                        (":hover:backdrop", "backdrop-hover"),
+                        (":active", "active"),
+                        (":disabled", "insensitive"),
+                        (":backdrop", "backdrop"),
+                        (":backdrop:disabled", 'backdrop-insensitive') {
       &#{$state} {
         @include check($t, $_c);
       }
@@ -2916,6 +2920,7 @@ radio {
       &#{$t} {
         @each $state, $t in ("", "normal"),
                             (":hover", "hover"),
+                            (":hover:backdrop", "backdrop-hover"),
                             (":disabled", "insensitive"),
                             (":backdrop", "backdrop"),
                             (":backdrop:disabled", 'backdrop-insensitive') {

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2554,7 +2554,12 @@ notebook {
         border-color: mix($borders_color, $base_color, 60%);
       }
 
-      &:backdrop { color: mix($backdrop_fg_color, $backdrop_bg_color, 60%); }
+      &:backdrop {
+        color: mix($backdrop_fg_color, $backdrop_bg_color, 60%);
+        &:hover {
+          border-color: mix($borders_color, $backdrop_bg_color, 65%);
+        }
+      }
 
       &:checked {
         color: $fg_color;

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1680,7 +1680,10 @@ headerbar {
       background-color: $c;
       color: $headerbar_text_color;
 
-      &:hover { box-shadow: inset 0 -2px transparentize($headerbar_text_color, 0.5); }
+      &:hover {
+        box-shadow: inset 0 -2px transparentize($headerbar_text_color, 0.5);
+        &:backdrop { box-shadow: inset 0 -2px transparentize($headerbar_text_color, 0.7); }
+      }
 
       &:active { box-shadow: inset 0 -2px $headerbar_text_color; }
 

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1229,7 +1229,11 @@ spinbutton {
       &:dir(rtl) { border-style: none solid none none; }
 
       &:hover {
-        background-color: if($variant=="light", darken($bg_color, 5%), lighten($bg_color, 25%));
+        background-color: if($light, darken($bg_color, 3%), lighten($bg_color, 15%));
+
+        &:backdrop {
+            background-color: lighten($backdrop_bg_color, 8%);
+        }
       }
 
       &:disabled {
@@ -1247,14 +1251,14 @@ spinbutton {
         background-color: transparent;
         border-color: transparentize($backdrop_borders_color, 0.7);
         transition: $backdrop_transition;
-      }
 
-      &:backdrop:disabled {
-        color: transparentize($insensitive_fg_color, 0.5);
-        background-color: transparent;
-        border-style: none none none solid; // It is needed or it gets overridden
+        &:disabled {
+            color: transparentize($insensitive_fg_color, 0.5);
+            background-color: transparent;
+            border-style: none none none solid; // It is needed or it gets overridden
 
-        &:dir(rtl) { border-style: none solid none none; }
+            &:dir(rtl) { border-style: none solid none none; }
+        }
       }
 
       &:dir(ltr):last-child { border-radius: 0 $small_radius $small_radius 0; }

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -556,7 +556,7 @@ button {
         &:active { transition: $button_transition; }
       }
 
-      @each $state, $t in (":hover", "hover"),
+      @each $state, $t in (":hover", "hover"), (":hover:backdrop", "backdrop-hover"),
       (":active, &:checked", "active"), (":disabled", "insensitive"),
       (":disabled:active, &:disabled:checked", "insensitive-active"), (":backdrop", "backdrop"),
       (":backdrop:active, &:backdrop:checked", 'backdrop-active'), (":backdrop:disabled", 'backdrop-insensitive'),
@@ -573,6 +573,8 @@ button {
       @include button(hover);
       -gtk-icon-effect: highlight;
       transition: $button_transition;
+
+      &:backdrop { @include button(backdrop-hover); }
     }
 
     &:active,
@@ -1439,7 +1441,7 @@ toolbar {
   padding: 4px 3px 3px 4px;
 
   button.flat {
-    @each $state, $t in ("", "normal"), (":hover", "hover"),
+    @each $state, $t in ("", "normal"), (":hover", "hover"), (":hover:backdrop", "backdrop-hover"),
     (":active, &:checked", "active"), (":disabled", "insensitive"),
     (":disabled:active, &:disabled:checked", "insensitive-active"), (":backdrop", "backdrop"),
     (":backdrop:active, &:backdrop:checked", 'backdrop-active'), (":backdrop:disabled", 'backdrop-insensitive'),
@@ -1606,6 +1608,7 @@ headerbar {
     button, button.flat, button.titlebutton.appmenu {
       @each $state, $t in ("", "normal"),
                           (":hover", "hover"),
+                          (":hover:backdrop", "backdrop-hover"),
                           (":active, &:checked", "active"),
                           (":hover:checked", "active-hover"),
                           (":disabled", "insensitive"),
@@ -1621,12 +1624,17 @@ headerbar {
                                   (destructive-action, $destructive_color) {
         &.#{$b_type} {
           // special buttons show their color when not interacted with
-          @each $state, $t in ("", "normal"), (":hover", "hover"),
-          (":active, &:checked", "active"), (":disabled", "insensitive"),
-          (":disabled:active, &:disabled:checked", "insensitive-active"), (":backdrop", "backdrop"),
-          (":backdrop:active, &:backdrop:checked", 'backdrop-active'), (":backdrop:disabled", 'backdrop-insensitive'),
-          (":backdrop:disabled:active, &:backdrop:disabled:checked", 'backdrop-insensitive-active') {
-            &#{$state} { @include button($t, $b_color, $tc, $flat:true); }
+          @each $state, $t in ("", "normal"),
+                              (":hover", "hover"),
+                              (":hover:backdrop", "backdrop-hover"),
+                              (":active, &:checked", "active"),
+                              (":disabled", "insensitive"),
+                              (":disabled:active, &:disabled:checked", "insensitive-active"),
+                              (":backdrop", "backdrop"),
+                              (":backdrop:active, &:backdrop:checked", 'backdrop-active'),
+                              (":backdrop:disabled", 'backdrop-insensitive'),
+                              (":backdrop:disabled:active, &:backdrop:disabled:checked", 'backdrop-insensitive-active') {
+            &#{$state} { @include button($t, $b_color, white, $flat:true); }
           }
         }
       }
@@ -1748,12 +1756,17 @@ headerbar {
     .subtitle:link { @extend *:link:selected;  }
 
     button {
-        @each $state, $t in ("", "normal"), (":hover", "hover"),
-        (":active, &:checked", "active"), (":disabled", "insensitive"),
-        (":disabled:active, &:disabled:checked", "insensitive-active"),
-        (":backdrop", "backdrop"), (":backdrop:active, &:backdrop:checked", 'backdrop-active'),
-        (":backdrop:disabled", 'backdrop-insensitive'), (":backdrop:disabled:active, &:backdrop:disabled:checked", 'backdrop-insensitive-active') {
-          $c: $success_color; //darken($success_color, 10%); // like the infobar
+        @each $state, $t in ("", "normal"),
+                            (":hover", "hover"),
+                            (":hover:backdrop", "backdrop-hover"),
+                            (":active, &:checked", "active"),
+                            (":disabled", "insensitive"),
+                            (":disabled:active, &:disabled:checked", "insensitive-active"),
+                            (":backdrop", "backdrop"),
+                            (":backdrop:active, &:backdrop:checked", 'backdrop-active'),
+                            (":backdrop:disabled", 'backdrop-insensitive'),
+                            (":backdrop:disabled:active, &:backdrop:disabled:checked", 'backdrop-insensitive-active') {
+          $c: $success_color;
           $tc: white;
           &, &.selection-menu {
             &#{$state} {
@@ -1781,7 +1794,7 @@ headerbar {
       }
 
       &.suggested-action {
-        @each $state, $t in ("", "normal"), (":hover", "hover"),
+        @each $state, $t in ("", "normal"), (":hover", "hover"), (":hover:backdrop", "backdrop-hover"),
         (":active", "active"), (":disabled", "insensitive"),
         (":backdrop", "backdrop"), (":backdrop:disabled", 'backdrop-insensitive') {
           $c: white;

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1181,6 +1181,11 @@ button:visited {
     text-decoration-line: underline;
   }
 
+  &:backdrop:hover {
+      background-color: transparent;
+      border-color: transparent;
+  }
+
 }
 
 

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -376,6 +376,8 @@
     $_bg: null;
     @if $c == $headerbar_bg_color {
       $_bg: $backdrop_headerbar_bg_color;
+    } @else if $c == $button_bg_color {
+      $_bg: $button_backdrop_bg_color;
     } @else {
       $_bg: _backdrop_color($c);
     }
@@ -387,7 +389,30 @@
 
     label, & { color: if($tc != $fg_color, mix($tc, $_bg, 60%), $backdrop_text_color); }
   }
+  @else if $t==backdrop-hover {
 
+    $_bg: null;
+    @if $c==$headerbar_bg_color { $_bg: lighten($backdrop_headerbar_bg_color, 15%); }
+    @else if $c==$success_color or $destructive_color or $neutral_color or $purple {
+      $_c: _backdrop_color($c);
+      $_bg: lighten($_c, 5%);
+    } @else if $c==$button_bg_color {
+      $_bg: if($light, lighten($button_backdrop_bg_color, 25%), lighten($button_backdrop_bg_color, 1%) );
+    }
+
+    background-color: $_bg;
+    color: $tc;
+
+    @if $flat {
+      border-color: $_bg;
+      box-shadow: none;
+    } @else {
+      border-color: $_border;
+      border-bottom-color: darken($_border, if($c == $headerbar_bg_color or $c == $button_bg_color, 15%, 12%));
+      box-shadow: 0 1px transparentize(black, 0.85);
+    }
+
+  }
   @else if $t==backdrop-active {
     // backdrop pushed button
 

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -686,6 +686,14 @@
     border-top-color: darken($bg, 10%);
     transition: $backdrop_transition;
 
+    &:hover {
+      background-color: $bg;
+
+      &:checked {
+        background-color: $alt;
+      }
+    }
+
     &:checked {
       background-color: _backdrop_color($alt);
       border-top-color: darken($alt, 10%);

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -391,7 +391,7 @@
 
   @else if $t==backdrop-hover {
     $_bg: null;
-    @if $c==$headerbar_bg_color { $_bg: lighten($backdrop_headerbar_bg_color, 5%); }
+    @if $c==$headerbar_bg_color { $_bg: lighten($backdrop_headerbar_bg_color, 6%); }
     @else if $c==$success_color or $destructive_color or $neutral_color or $purple {
       $_c: _backdrop_color($c);
       $_bg: lighten($_c, 5%);
@@ -885,44 +885,44 @@
 }
 
 @mixin draw_circle($c, $close:false, $size:24px) {
-$button_size: $size + 2px * 2;
-$circle_size: 20px / $button_size / 2;
+    $button_size: $size + 2px * 2;
+    $circle_size: 20px / $button_size / 2;
 
-  background-image: -gtk-gradient(radial,
-                                  center center, 0,
-                                  center center, $circle_size,
-                                  to($c),
-                                  to(transparent));
-
-  &:hover {
-    $_bg: if(lightness($c)<35%, lighten($c, 25%), lighten($c, 5%));
-    background-image: -gtk-gradient(radial,
-                                  center center, 0,
-                                  center center, $circle_size,
-                                  to($_bg),
-                                  to(transparent));
-  }
-
-  &:active {
-    $_bg: if(lightness($c)<35%, lighten($c, 18%), darken($c, 7%));
     background-image: -gtk-gradient(radial,
                                     center center, 0,
                                     center center, $circle_size,
-                                    to($_bg),
+                                    to($c),
                                     to(transparent));
-}
 
-@if $close == true {
-  &:backdrop {
-    color: $backdrop_headerbar_fg_color;
-    &:backdrop:hover {
-      $_bg: lighten($headerbar_bg_color, 25%);
-      background-image: -gtk-gradient(radial,
-                                    center center, 0,
-                                    center center, $circle_size,
-                                    to($_bg),
-                                    to(transparent));
+    &:hover {
+        $_bg: if(lightness($c)<35%, lighten($c, 25%), lighten($c, 5%));
+        background-image: -gtk-gradient(radial,
+                                        center center, 0,
+                                        center center, $circle_size,
+                                        to($_bg),
+                                        to(transparent));
+        &:backdrop {
+            $_bg: lighten($backdrop_headerbar_bg_color, 8%);
+            background-image: -gtk-gradient(radial,
+                                        center center, 0,
+                                        center center, $circle_size,
+                                        to($_bg),
+                                        to(transparent));
+        }
     }
+
+    &:active {
+        $_bg: if(lightness($c)<35%, lighten($c, 18%), darken($c, 7%));
+        background-image: -gtk-gradient(radial,
+                                        center center, 0,
+                                        center center, $circle_size,
+                                        to($_bg),
+                                        to(transparent));
     }
-  }
+
+    @if $close == true {
+        &:backdrop {
+            color: $backdrop_headerbar_fg_color;
+        }
+    }
 }

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -399,10 +399,10 @@
       $_bg: if($light, lighten($button_backdrop_bg_color, 25%), lighten($button_backdrop_bg_color, 1%) );
     }
 
-    background-color: $_bg;
     color: $tc;
 
     @if $flat {
+      background-color: $_bg;
       border-color: $_bg;
       box-shadow: none;
     } @else {

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -206,7 +206,7 @@
   //
   // possible $t values:
   // normal, hover, active, insensitive, insensitive-active,
-  // backdrop, backdrop-active, backdrop-insensitive, backdrop-insensitive-active,
+  // backdrop, backdrop-hover, backdrop-active, backdrop-insensitive, backdrop-insensitive-active,
   // osd, osd-hover, osd-active, osd-insensitive, osd-backdrop, undecorated
 
   $_pressed: if(lightness($c)<15%, transparentize(black, 0.4), transparentize(black, 0.8));
@@ -388,10 +388,10 @@
 
     label, & { color: if($tc != $fg_color, mix($tc, $_bg, 60%), $backdrop_text_color); }
   }
-  @else if $t==backdrop-hover {
 
+  @else if $t==backdrop-hover {
     $_bg: null;
-    @if $c==$headerbar_bg_color { $_bg: lighten($backdrop_headerbar_bg_color, 15%); }
+    @if $c==$headerbar_bg_color { $_bg: lighten($backdrop_headerbar_bg_color, 5%); }
     @else if $c==$success_color or $destructive_color or $neutral_color or $purple {
       $_c: _backdrop_color($c);
       $_bg: lighten($_c, 5%);
@@ -410,7 +410,6 @@
       border-bottom-color: darken($_border, if($c == $headerbar_bg_color or $c == $button_bg_color, 15%, 12%));
       box-shadow: 0 1px transparentize(black, 0.85);
     }
-
   }
   @else if $t==backdrop-active {
     // backdrop pushed button

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -624,6 +624,11 @@
     color: $tc;
   }
 
+  @if $t==backdrop-hover {
+    -gtk-icon-effect: highlight;
+    background-color: if($c!=white, lighten($c, 9%), darken($c, 7%));
+  }
+
   @if $t==backdrop-insensitive {
     -gtk-icon-effect: dim;
 

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -17,12 +17,6 @@
   }
 }
 
-// @function _widget_edge($c:$borders_edge) {
-// // outer highlight "used" on most widgets
-//   @if $c == none { @return none; }
-//   @else { @return 0 1px $c; }
-// }
-
 @mixin _shadows($list...) {
 //
 // Helper mixin to stack up to box-shadows;

--- a/Communitheme/gtk-3.0/_drawing.scss
+++ b/Communitheme/gtk-3.0/_drawing.scss
@@ -4,14 +4,13 @@
 
 @function _backdrop_color($c) {
   // adjusts colors for use in the backdrop state
-  @if $variant == 'light' {
-    @return lighten($c, 5%);
+  @if $light {
+    @return if($c!=white, lighten($c, 5%), transparentize(white, 0.3));
   }
-  @else if $variant == 'dark'{
+  @else {
     @if $c==$orange or $c==$hb_pathbar_bg {
       @return lighten($c, 5%);
-    }
-    @else {
+    } @else {
       @return darken($c, 2%);
     }
   }


### PR DESCRIPTION
This PR re-introduces hover effect on backdropped wigets.

Since the list of widgets is long, I though it would have been better to give immediatly a snap branch to test and a PR on which discuss and remind widgets I might have forgotten

TODOs
- [X] tabs
- [x] list
- [x] window control buttons
- [x] pathbar (underline effect)
- [x] stack switcher (underline effect)
- [x] spinbutton
- [x] link
- [x] scale (this has never been removed actually)
- [x] check/radio buttons
- [x] headerbar buttons
- [x] normal buttons
- [x] switch

closes #194 



