### PR TITLE
Firefox fixes

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -439,3 +439,24 @@ window.background.chromium {
  *********************/
 //removes the black background for picture tiles
 .documents-scrolledwin.frame.frame widget flowboxchild.tile { background-color: transparent; }
+
+/*********************
+ * Firefox *
+ *********************/
+#MozillaGtkWidget.background  {
+  > widget {
+    > scrolledwindow > textview {
+      text {
+        &:selected { @extend %selected_text; border-color: $selected_bg_color;}
+      }
+    }
+  }
+
+  headerbar.titlebar {
+    //Remove the round corners until firefox fixed the white border bleed at the top edges
+    border-radius: 0;
+  }
+
+  > menu, .menu { border: none; } // Removed ugly menu borders
+  > menu > menuitem { border-radius: 0; } // Removed rounded menu corners
+}

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2321,11 +2321,7 @@ menuitem {
   }
 }
 
-window.background:not(.csd) {
-  // Firefox menu
-  > menu, .menu { border: none; } // Removed ugly menu borders
-  > menu > menuitem { border-radius: 0; } // Removed rounded menu corners
-}
+
 
 /***************
  * Popovers   *


### PR DESCRIPTION
![screenshot from 2018-06-19 01-20-23](https://user-images.githubusercontent.com/15329494/41567129-02fbe8d4-735f-11e8-864e-97bb580be794.png)


Work in progress:

- [x] make selected text "mads-blue" (TM)
- [ ] don't change the tab hightlight color and the urlbox focus color with this 
- [x] remove the border-bleed at the left and right corner of the CSD titlebar
- [x] move existing firefox code to _apps.scss