### PR TITLE
Treat horizontal spinbuttons as buttons, like vertical spinbuttons

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1218,21 +1218,25 @@ spinbutton {
       border-color: $borders_edge;
       border-radius: 0;
       box-shadow: none;
+      @include button(normal);
 
       &:dir(rtl) { border-style: none solid none none; }
 
       &:hover {
         background-color: if($variant=="light", darken($bg_color, 5%), lighten($bg_color, 25%));
+        @include button(hover);
       }
 
       &:disabled {
         color: transparentize($insensitive_fg_color, 0.4);
         background-color: transparent;
+        @include button(insensitive);
       }
 
       &:active {
         background-color: transparentize(black, 0.9);
         box-shadow: inset 0 2px 3px -1px transparentize(black, 0.8);
+        @include button(active);
       }
 
       &:backdrop {
@@ -1240,14 +1244,19 @@ spinbutton {
         background-color: transparent;
         border-color: transparentize($backdrop_borders_color, 0.7);
         transition: $backdrop_transition;
+        @include button(backdrop);
       }
 
       &:backdrop:disabled {
         color: transparentize($insensitive_fg_color, 0.5);
         background-color: transparent;
         border-style: none none none solid; // It is needed or it gets overridden
+        @include button(backdrop-insensitive);
 
         &:dir(rtl) { border-style: none solid none none; }
+      }
+      &:backdrop:hover {
+        @include button(backdrop-hover);
       }
 
       &:dir(ltr):last-child { border-radius: 0 $small_radius $small_radius 0; }


### PR DESCRIPTION
![peek 2018-06-19 23-15](https://user-images.githubusercontent.com/15329494/41624641-ac3ee042-7416-11e8-9bf4-1fbb90bbf51b.gif)

@madsrh @clobrano 

I've "noticed" that the vertical spinbuttons already worked like regular non flat buttons and was wondering why the horizontal don't. By adding the button functions they now work like regular buttons, too. Are you +1 with this "last-minute" change?