### PR TITLE
Box-shadows to style gnome-software

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -275,7 +275,7 @@ terminal-window {
 .star{
   @if $variant=='dark'{
     border-radius: $small_radius;
-    box-shadow: inset 0 0 10px 10px transparentize(white, 0.1);
+    box-shadow: inset 0 0 10px 10px #fdfdfd;
   }
 }
 //Background color can not be set, so use a inset-box-shadow

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -271,6 +271,21 @@ terminal-window {
   margin: -1px 0;
 }
 
+//Star color can not be set, so this gives the stars a background in the dark theme
+.star{
+  @if $variant=='dark'{
+    border-radius: $small_radius;
+    box-shadow: inset 0 0 10px 10px transparentize(white, 0.1);
+  }
+}
+//Background color can not be set, so use a inset-box-shadow
+.application-details-infobar {
+  box-shadow: inset 0 0 100px 100px $base_color;
+}
+.category_page_header_filter_box  {
+    box-shadow: inset 0 0 100px 100px $base_color;
+}
+
 /***********
  * Gedit *
  ***********/


### PR DESCRIPTION
Closes https://github.com/ubuntu/gtk-communitheme/issues/559

Also fixes the light theme which looks this way in master : 
![image](https://user-images.githubusercontent.com/15329494/41963492-07416d2a-79f8-11e8-9e49-3cf489d9ea87.png)
