### PR TITLE
Improved hover effect to GTK3 toolbar button

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1451,12 +1451,17 @@ toolbar {
   padding: 4px 3px 3px 4px;
 
   button.flat {
-    @each $state, $t in ("", "normal"), (":hover", "hover"), (":hover:backdrop", "backdrop-hover"),
-    (":active, &:checked", "active"), (":disabled", "insensitive"),
-    (":disabled:active, &:disabled:checked", "insensitive-active"), (":backdrop", "backdrop"),
-    (":backdrop:active, &:backdrop:checked", 'backdrop-active'), (":backdrop:disabled", 'backdrop-insensitive'),
-    (":backdrop:disabled:active, &:backdrop:disabled:checked", 'backdrop-insensitive-active') {
-      &#{$state} { @include button($t, $flat:true); }
+    @each $state, $t, $is_flat in ("", "normal", true),
+                                  (":hover", "hover", false),
+                                  (":hover:backdrop", "backdrop-hover", false),
+                                  (":active, &:checked", "active", true),
+                                  (":disabled", "insensitive", true),
+                                  (":disabled:active, &:disabled:checked", "insensitive-active", true),
+                                  (":backdrop", "backdrop", true),
+                                  (":backdrop:active, &:backdrop:checked", 'backdrop-active', true),
+                                  (":backdrop:disabled", 'backdrop-insensitive', true),
+                                  (":backdrop:disabled:active, &:backdrop:disabled:checked", 'backdrop-insensitive-active', true) {
+      &#{$state} { @include button($t, $c:$menu_color, $flat:$is_flat); }
     }
 
     &, &:backdrop { &, &:disabled { background-color: transparent; border-color: transparent; } }


### PR DESCRIPTION
(Sorry, I forgot to PR this)

hover effect on GTK3 toolbar buttons is hard to see. For GTK2 toolbar buttons
have the same hover effect than normal buttons, which makes them easy and
pleasant to see.

Then, this commit applies the same hover effect to GTK3 toolbar button

closes #571