### PR TITLE
Added a dark border to toolbar button on hover

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1451,19 +1451,20 @@ toolbar {
   padding: 4px 3px 3px 4px;
 
   button.flat {
-    @each $state, $t, $is_flat in ("", "normal", true),
-                                  (":hover", "hover", false),
-                                  (":hover:backdrop", "backdrop-hover", false),
-                                  (":active, &:checked", "active", true),
-                                  (":disabled", "insensitive", true),
-                                  (":disabled:active, &:disabled:checked", "insensitive-active", true),
-                                  (":backdrop", "backdrop", true),
-                                  (":backdrop:active, &:backdrop:checked", 'backdrop-active', true),
-                                  (":backdrop:disabled", 'backdrop-insensitive', true),
-                                  (":backdrop:disabled:active, &:backdrop:disabled:checked", 'backdrop-insensitive-active', true) {
-      &#{$state} { @include button($t, $c:$menu_color, $flat:$is_flat); }
+    @each $state, $t, $is_flat in ("", "normal"),
+                                  (":hover", "hover"),
+                                  (":hover:backdrop", "backdrop-hover"),
+                                  (":active, &:checked", "active"),
+                                  (":disabled", "insensitive"),
+                                  (":disabled:active, &:disabled:checked", "insensitive-active"),
+                                  (":backdrop", "backdrop"),
+                                  (":backdrop:active, &:backdrop:checked", 'backdrop-active'),
+                                  (":backdrop:disabled", 'backdrop-insensitive'),
+                                  (":backdrop:disabled:active, &:backdrop:disabled:checked", 'backdrop-insensitive-active') {
+      &#{$state} { @include button($t, $c:$menu_color, $flat:true); }
     }
 
+    &:hover { background: $menu_color; border-color: darken($menu_color, 30%); }
     &, &:backdrop { &, &:disabled { background-color: transparent; border-color: transparent; } }
   }
 


### PR DESCRIPTION
New iteration of toolbar button hover. This change tries again to
mimic GTK2 behavior, this time adding a darker border and a brighter
background color

closes #571 

![toolbar-hover-non-flat](https://user-images.githubusercontent.com/2883614/42137525-fd33c5c0-7d6d-11e8-9d36-f3e973971923.gif)

- [ ] see #614 first
