### PR TITLE
Fixes terminal tab backdrop hover

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -119,7 +119,7 @@ terminal-window {
     color: $terminal_fg_color;
 
     &:backdrop {
-      background-color: _backdrop_color($terminal_bg_color);
+      background-color: lighten($terminal_bg_color, 2%);
       color: $backdrop_selected_fg_color;
     }
   }

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -153,8 +153,8 @@ terminal-window {
             }
           }
 
-          &:backdrop { color: $backdrop_headerbar_fg_color; }
           &, &:backdrop {
+            color: $backdrop_headerbar_fg_color;
             &, &:disabled {
               background-color: transparent;
               border-color: transparent;

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -140,31 +140,31 @@ terminal-window {
 
       button.flat {
         &, &:backdrop {
-        color: $terminal_fg_color;
-        @each $state, $t in (':hover', 'hover'),
-                            (':active, &:checked', 'active'),
-                            (':backdrop', 'backdrop'),
-                            (':backdrop-hover', 'backdrop-hover'),
-                            (':backdrop:disabled', 'backdrop-insensitive'),
-                            (':disabled', 'insensitive') {
+          color: $terminal_fg_color;
+          @each $state, $t in (':hover', 'hover'),
+          (':active, &:checked', 'active'),
+          (':backdrop', 'backdrop'),
+          (':backdrop-hover', 'backdrop-hover'),
+          (':backdrop:disabled', 'backdrop-insensitive'),
+          (':disabled', 'insensitive') {
             &#{$state} {
               @include button($t, $headerbar_bg_color, $headerbar_bg_color, $flat:true);
               color: white;
             }
-        }
+          }
 
-        &:backdrop { color: $backdrop_headerbar_fg_color; }
-        &, &:backdrop {
-          &, &:disabled {
-            background-color: transparent;
-            border-color: transparent;
+          &:backdrop { color: $backdrop_headerbar_fg_color; }
+          &, &:backdrop {
+            &, &:disabled {
+              background-color: transparent;
+              border-color: transparent;
+            }
           }
         }
       }
-    }
 
       &:backdrop {
-        border-color: _backdrop_color($terminal_borders_color);
+        border-color: $inkstone;
         background-color: _backdrop_color($backdrop_headerbar_bg_color);
       }
 

--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -139,10 +139,12 @@ terminal-window {
       background-color: $headerbar_bg_color;
 
       button.flat {
+        &, &:backdrop {
         color: $terminal_fg_color;
         @each $state, $t in (':hover', 'hover'),
                             (':active, &:checked', 'active'),
                             (':backdrop', 'backdrop'),
+                            (':backdrop-hover', 'backdrop-hover'),
                             (':backdrop:disabled', 'backdrop-insensitive'),
                             (':disabled', 'insensitive') {
             &#{$state} {
@@ -159,6 +161,7 @@ terminal-window {
           }
         }
       }
+    }
 
       &:backdrop {
         border-color: _backdrop_color($terminal_borders_color);
@@ -170,10 +173,12 @@ terminal-window {
 
         color: $ash;
 
+        &:hover:backdrop {
+          border-color: lighten($headerbar_bg_color, 4%);
+        }
+
         &:hover:not(:active):not(:backdrop):not(:checked) {
-          background-color: $headerbar_bg_color;
           background-color: lighten($headerbar_bg_color, 4%);
-          border-color: $_border_color;
           border-color: $inkstone;
         }
 


### PR DESCRIPTION
Give terminal unchecked backdrop tab hover proper border and background
colors

closes #591 
![peek 2018-07-06 23-09](https://user-images.githubusercontent.com/2883614/42400419-c6527904-8171-11e8-9dd5-62e29bb0b1c8.gif)
