### PR TITLE
Improved backdrop hover in nautilus tabs

### DIFF
--- a/Communitheme/gtk-3.0/_apps.scss
+++ b/Communitheme/gtk-3.0/_apps.scss
@@ -144,7 +144,8 @@ terminal-window {
           @each $state, $t in (':hover', 'hover'),
           (':active, &:checked', 'active'),
           (':backdrop', 'backdrop'),
-          (':backdrop-hover', 'backdrop-hover'),
+          (':backdrop:hover', 'backdrop-hover'),
+          (':backdrop:checked:hover', 'backdrop-active'),
           (':backdrop:disabled', 'backdrop-insensitive'),
           (':disabled', 'insensitive') {
             &#{$state} {
@@ -160,6 +161,7 @@ terminal-window {
               border-color: transparent;
             }
           }
+          &:backdrop:hover { border-color: $inkstone; }
         }
       }
 


### PR DESCRIPTION
Missing commit from #609 

improved hover effect also on other buttons in the tabs area that are not
part of the tab. Added also a darker border to the buttons above and to
the close tab button of unchecked tab. Checked tab close button gets a
background highlight instead.

