### PR TITLE
Toolbar button hover added missing border color on hover

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1454,9 +1454,9 @@ toolbar {
     @each $state, $t, $is_flat in ("", "normal", true),
                                   (":hover", "hover", false),
                                   (":hover:backdrop", "backdrop-hover", false),
-                                  (":active, &:checked", "active", true),
+                                  (":active, &:checked", "active", false),
                                   (":disabled", "insensitive", true),
-                                  (":disabled:active, &:disabled:checked", "insensitive-active", true),
+                                  (":disabled:active, &:disabled:checked", "insensitive-active", false),
                                   (":backdrop", "backdrop", true),
                                   (":backdrop:active, &:backdrop:checked", 'backdrop-active', true),
                                   (":backdrop:disabled", 'backdrop-insensitive', true),
@@ -1464,7 +1464,7 @@ toolbar {
       &#{$state} { @include button($t, $c:$menu_color, $flat:$is_flat); }
     }
 
-    &:hover { border-color: $borders_color; }
+    &:hover, &:checked { border-color: $borders_color; }
     &, &:backdrop { &, &:disabled { background-color: transparent; border-color: transparent; } }
   }
 

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1464,6 +1464,7 @@ toolbar {
       &#{$state} { @include button($t, $c:$menu_color, $flat:$is_flat); }
     }
 
+    &:hover { border-color: $borders_color; }
     &, &:backdrop { &, &:disabled { background-color: transparent; border-color: transparent; } }
   }
 


### PR DESCRIPTION
Adding the missing border color that non-flat buttons have on hover

![peek 2018-07-07 17-33](https://user-images.githubusercontent.com/2883614/42412403-0a2213c0-820c-11e8-8f38-c2785f18ff8f.gif)

closes #571 