### PR TITLE
Fixed headerbar separator color

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1578,9 +1578,14 @@ headerbar {
     @extend .dim-label;
   }
 
+  & > separator {
+      background-image: image(mix($inkstone, $headerbar_bg_color, 50%));
+      &:backdrop { background-image: image(mix(darken($inkstone, 5%), $backdrop_headerbar_bg_color, 50%)); }
+  }
+
   ~ separator, separator {
     &, &.titlebutton {
-      &, &.horizontal, &.vertical {
+     &.horizontal, &.vertical {
         & { background-image: image(mix($inkstone, $headerbar_bg_color, 50%)); }
         &:backdrop { background-image: image(mix(darken($inkstone, 5%), $backdrop_headerbar_bg_color, 50%)); }
       }


### PR DESCRIPTION
separator in a contextual menu of pathbar (e.g. Nautilus) takes the same
color of a headerbar separator. Being the latter dark and the first
bright, the same color can not be used, causing issue #576

Reorganized the code to avoid to style such contextual menu separator as
if it was in a headerbar.

closes #576

![peek 2018-07-09 19-20](https://user-images.githubusercontent.com/2883614/42465753-2ecd37c0-83ad-11e8-8805-1811ac27893e.gif)


consider that this lines of code are used to style both headerbar's horizontal separator and Gedit paned separator as well

![image](https://user-images.githubusercontent.com/2883614/42465680-fad83eb0-83ac-11e8-82b0-63f5ada2f024.png)
![image](https://user-images.githubusercontent.com/2883614/42465688-01c6f84c-83ad-11e8-9e33-e67edeb5a957.png)





