### PR TITLE
colorswatch hover and roundness

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -2,15 +2,6 @@
   @return unquote("alpha(#{$c},#{$a})");
 }
 
-$ease-out-quad: cubic-bezier(0.25, 0.46, 0.45, 0.94);
-$asset_suffix: if($variant=='dark', '-dark', '');
-$small_radius: 4px;
-$medium_radius: 6px;
-$large_radius: 12px;
-$backdrop_transition: all 200ms ease-out;
-$button_transition: all 0.4s ease-out;
-$popover_shadow: 0 2px 5px transparentize(black, 0.75);
-
 * {
   padding: 0;
   -GtkToolButton-icon-spacing: 4;
@@ -43,6 +34,14 @@ $popover_shadow: 0 2px 5px transparentize(black, 0.75);
   -gtk-secondary-caret-color: $selected_bg_color
 }
 
+$ease-out-quad: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+$asset_suffix: if($variant=='dark', '-dark', '');
+$small_radius: 4px;
+$medium_radius: 6px;
+$large_radius: 12px;
+$backdrop_transition: all 200ms ease-out;
+$button_transition: all 0.4s ease-out;
+$popover_shadow: 0 2px 5px transparentize(black, 0.75);
 
 /***************
  * Base States *
@@ -4397,6 +4396,7 @@ colorswatch {
       &:hover { border-color: if($variant == 'light', transparentize(black, 0.2), $borders_color); }
 
       &:backdrop { color: transparentize(white, 0.5); }
+      &:hover { border-color: if($variant == 'light', transparentize(black, 0.3), $borders_color); }
     }
   }
 
@@ -4409,6 +4409,7 @@ colorswatch {
       &:hover { border-color: if($variant == 'light', transparentize(black, 0.5), $borders_color); }
 
       &:backdrop { color: transparentize(black, 0.5); }
+      &:backdrop:hover { border-color: if($variant == 'light', transparentize(black, 0.6), $borders_color); }
     }
   }
 
@@ -4431,10 +4432,10 @@ colorswatch {
   overlay {
     border: 1px solid if($variant == 'light', transparentize(black, 0.7), $borders_color);
 
-    &:hover {
-      box-shadow: inset 0 1px transparentize(white, 0.6),
-                  inset 0 -1px transparentize(black, 0.8);
-    }
+    //&:hover {
+    //  box-shadow: inset 0 1px transparentize(white, 0.6),
+    //              inset 0 -1px transparentize(black, 0.8);
+    //}
 
     &:backdrop, &:backdrop:hover {
       border-color: if($variant == 'light', transparentize(black, 0.7), $borders_color);

--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4335,57 +4335,7 @@ colorswatch {
 
   &:drop(active), & { border-style: none; } // FIXME: implement a proper drop(active) state
 
-  $_colorswatch_radius: 5px;
   outline-offset: -2px;
-  -gtk-outline-radius: $_colorswatch_radius;
-
-
-  // base color corners rounding
-  // to avoid the artifacts caused by rounded corner anti-aliasing the base color
-  // sports a bigger radius.
-  // nth-child is needed by the custom color strip.
-
-  &.top {
-    border-top-left-radius: $_colorswatch_radius + 0.5px;
-    border-top-right-radius: $_colorswatch_radius + 0.5px;
-
-    overlay {
-      border-top-left-radius: $_colorswatch_radius;
-      border-top-right-radius: $_colorswatch_radius;
-    }
-  }
-
-  &.bottom {
-    border-bottom-left-radius: $_colorswatch_radius + 0.5px;
-    border-bottom-right-radius: $_colorswatch_radius + 0.5px;
-
-    overlay {
-      border-bottom-left-radius: $_colorswatch_radius;
-      border-bottom-right-radius: $_colorswatch_radius;
-    }
-  }
-
-  &.left,
-  &:first-child:not(.top) {
-    border-top-left-radius: $_colorswatch_radius + 0.5px;
-    border-bottom-left-radius: $_colorswatch_radius + 0.5px;
-
-    overlay {
-      border-top-left-radius: $_colorswatch_radius;
-      border-bottom-left-radius: $_colorswatch_radius;
-    }
-  }
-
-  &.right,
-  &:last-child:not(.bottom) {
-    border-top-right-radius: $_colorswatch_radius + 0.5px;
-    border-bottom-right-radius: $_colorswatch_radius + 0.5px;
-
-    overlay {
-      border-top-right-radius: $_colorswatch_radius;
-      border-bottom-right-radius: $_colorswatch_radius;
-    }
-  }
 
   &.dark {
     outline-color: transparentize(white, 0.4);
@@ -4444,10 +4394,6 @@ colorswatch {
   }
 
   &#add-color-button {
-    border-radius: $_colorswatch_radius $_colorswatch_radius 0 0;
-
-    &:only-child { border-radius: $_colorswatch_radius; }
-
     overlay {
       @include button(normal);
 


### PR DESCRIPTION
closes #611

This is actually made of two commits, the second is optional, so wait for @madsrh to review it before merging it (EDIT: I forgot he's on vacation :D)

1st commit removes top border highlight from the widget
![color-chooser-hover](https://user-images.githubusercontent.com/2883614/42726567-c723021a-8796-11e8-8587-84e80d79a277.gif)

2nd commit makes the color button squared 
![color-chooser-square](https://user-images.githubusercontent.com/2883614/42726564-c137c20a-8796-11e8-91e6-8f89b1405367.gif)